### PR TITLE
Most significant bit and bool-to-int conversions.

### DIFF
--- a/BenchmarkDotNet.Samples/Algo_MostSignificantBit.cs
+++ b/BenchmarkDotNet.Samples/Algo_MostSignificantBit.cs
@@ -1,0 +1,139 @@
+﻿using BenchmarkDotNet.Tasks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace BenchmarkDotNet.Samples
+{
+    [Task(platform: BenchmarkPlatform.X64, jitVersion: BenchmarkJitVersion.LegacyJit)]
+    [Task(platform: BenchmarkPlatform.X64, jitVersion: BenchmarkJitVersion.RyuJit)]
+    public class Algo_MostSignificantBit
+    {
+        private const int N = 4001;
+        private readonly int[] numbers;
+        private readonly Random random = new Random(42);
+
+        public Algo_MostSignificantBit()
+        {
+            numbers = new int[N];
+            for (int i = 0; i < N; i++)
+                numbers[i] = random.Next();
+        }
+
+        [Benchmark]
+        public int MostSignificantDeBruijn()
+        {
+            int counter = 0;
+            for (int i = 0; i < N; i++)
+                counter += BitHelper.MostSignificantDeBruijn(numbers[i]);
+            return counter;
+        }
+
+        [Benchmark]
+        public int MostSignificantNaive()
+        {
+            int counter = 0;
+            for (int i = 0; i < N; i++)
+                counter += BitHelper.MostSignificantNaive(numbers[i]);
+            return counter;
+        }
+
+        [Benchmark]
+        public int MostSignificantShifted()
+        {
+            int counter = 0;
+            for (int i = 0; i < N; i++)
+                counter += BitHelper.MostSignificantShifted(numbers[i]);
+            return counter;
+        }
+
+        [Benchmark]
+        public int MostSignificantBranched()
+        {
+            int counter = 0;
+            for (int i = 0; i < N; i++)
+                counter += BitHelper.MostSignificantBranched(numbers[i]);
+            return counter;
+        }
+
+        public static class BitHelper
+        {
+            // Code taken from http://graphics.stanford.edu/~seander/bithacks.html#IntegerLogDeBruijn
+
+            private static readonly int[] MultiplyDeBruijnBitPosition = new int[]
+                {
+                    0, 9, 1, 10, 13, 21, 2, 29, 11, 14, 16, 18, 22, 25, 3, 30,
+                    8, 12, 20, 28, 15, 17, 24, 7, 19, 27, 23, 6, 26, 5, 4, 31
+                };
+
+            public static int MostSignificantDeBruijn(int v)
+            {
+                v |= v >> 1; // first round down to one less than a power of 2 
+                v |= v >> 2;
+                v |= v >> 4;
+                v |= v >> 8;
+                v |= v >> 16;
+
+                return MultiplyDeBruijnBitPosition[(uint)(v * 0x07C4ACDDU) >> 27];
+            }
+
+            public static int MostSignificantNaive(int n)
+            {
+                int r = 0;
+
+                n >>= 1;
+                while (n != 0)
+                {
+                    r++;
+                    n >>= 1;
+                }
+
+                return r;
+            }
+
+            private static readonly int[] BranchedValues = new int[] { 0,1,2,2,3,3,3,3,4,4,4,4,4,4,4,4 };
+
+            public static int MostSignificantBranched(int x)
+            {
+                if (x == 0)
+                    return 0;
+
+                int r = 0;
+                if ((x & 0xFFFF0000) != 0) { r += 16 / 1; x >>= 16 / 1; }
+                if ((x & 0x0000FF00) != 0) { r += 16 / 2; x >>= 16 / 2; }
+                if ((x & 0x000000F0) != 0) { r += 16 / 4; x >>= 16 / 4; }
+                return r + BranchedValues[x] - 1;
+            }
+
+
+            public static int MostSignificantShifted(int n)
+            {
+                uint v = (uint)n;           // 32-bit value to find the log2 of 
+                uint r;                     // result of log2(v) will go here
+                uint shift;
+
+                unsafe
+                {
+                    bool cond = v > 0xFFFF;
+                    r = *(uint*)(&cond) << 4;
+
+                    v >>= (int)r;
+
+                    cond = v > 0xFF;
+                    shift = *(uint*)(&cond) << 3; v >>= (int)shift; r |= shift;
+
+                    cond = v > 0xF;
+                    shift = *(uint*)(&cond) << 2; v >>= (int)shift; r |= shift;
+
+                    cond = v > 0x3;
+                    shift = *(uint*)(&cond) << 1; v >>= (int)shift; r |= shift;
+
+                    r |= (v >> 1);
+
+                    return (int)r;
+                }
+            }
+        }
+    }
+}

--- a/BenchmarkDotNet.Samples/BenchmarkDotNet.Samples.csproj
+++ b/BenchmarkDotNet.Samples/BenchmarkDotNet.Samples.csproj
@@ -34,6 +34,7 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>5</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -46,6 +47,7 @@
   <ItemGroup>
     <Compile Include="Algo_BitCount.cs" />
     <Compile Include="Algo_Md5VsSha256.cs" />
+    <Compile Include="Algo_MostSignificantBit.cs" />
     <Compile Include="Cpu_BranchPerdictor.cs" />
     <Compile Include="Cpu_Ilp_Inc.cs" />
     <Compile Include="Il_ReadonlyFields.cs" />
@@ -58,6 +60,7 @@
     <Compile Include="Jit_Bce.cs" />
     <Compile Include="Cpu_MatrixMultiplication.cs" />
     <Compile Include="Cpu_Ilp_Max.cs" />
+    <Compile Include="Jit_BoolToInt.cs" />
     <Compile Include="Jit_Inlining.cs" />
     <Compile Include="Jit_InterfaceMethod.cs" />
     <Compile Include="Jit_LoopUnrolling.cs" />

--- a/BenchmarkDotNet.Samples/Jit_BoolToInt.cs
+++ b/BenchmarkDotNet.Samples/Jit_BoolToInt.cs
@@ -10,49 +10,43 @@ namespace BenchmarkDotNet.Samples
     [Task(platform: BenchmarkPlatform.X64, jitVersion: BenchmarkJitVersion.RyuJit)]
     public class Jit_BoolToInt
     {
-        private const int N = 1001;
-        private readonly bool[] bits;
+        private bool first;
+        private bool second;
 
         public Jit_BoolToInt()
         {
-            bits = new bool[N];
-            for (int i = 0; i < N; i++)
-                bits[i] = i % 2 == 0;
+            first = true;
+            second = false;
         }
 
         [Benchmark]
         public int Framework()
         {
-            int sum = 0;
-            for (int i = 0; i < N; i++)
-                sum += Convert.ToInt32(bits[i]);
-
+            int sum = Convert.ToInt32(first);
+            sum += Convert.ToInt32(second);
             return sum;
         }
 
         [Benchmark]
         public int IfThenElse()
         {
-            int sum = 0;
-            for (int i = 0; i < N; i++)
-                sum += bits[i] ? 1 : 0;
-
+            int sum = first ? 1 : 0;
+            sum += second ? 1 : 0;
             return sum;
         }
 
         [Benchmark]
         public int UnsafeConvert()
         {
-            int sum = 0;
             unsafe
             {
-                for (int i = 0; i < N; i++)
-                {
-                    bool v = bits[i];
-                    sum += *(int*)(&v);
-                }
+                bool v1 = first;
+                int sum = *(int*)(&v1);
+
+                bool v2 = second;
+                sum += *(int*)(&v2);
+                return sum;
             }
-            return sum;
         }
     }
 }

--- a/BenchmarkDotNet.Samples/Jit_BoolToInt.cs
+++ b/BenchmarkDotNet.Samples/Jit_BoolToInt.cs
@@ -1,0 +1,58 @@
+﻿using BenchmarkDotNet.Tasks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace BenchmarkDotNet.Samples
+{
+    [Task(platform: BenchmarkPlatform.X64, jitVersion: BenchmarkJitVersion.LegacyJit)]
+    [Task(platform: BenchmarkPlatform.X64, jitVersion: BenchmarkJitVersion.RyuJit)]
+    public class Jit_BoolToInt
+    {
+        private const int N = 1001;
+        private readonly bool[] bits;
+
+        public Jit_BoolToInt()
+        {
+            bits = new bool[N];
+            for (int i = 0; i < N; i++)
+                bits[i] = i % 2 == 0;
+        }
+
+        [Benchmark]
+        public int Framework()
+        {
+            int sum = 0;
+            for (int i = 0; i < N; i++)
+                sum += Convert.ToInt32(bits[i]);
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int IfThenElse()
+        {
+            int sum = 0;
+            for (int i = 0; i < N; i++)
+                sum += bits[i] ? 1 : 0;
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int UnsafeConvert()
+        {
+            int sum = 0;
+            unsafe
+            {
+                for (int i = 0; i < N; i++)
+                {
+                    bool v = bits[i];
+                    sum += *(int*)(&v);
+                }
+            }
+            return sum;
+        }
+    }
+}

--- a/BenchmarkDotNet.Samples/Jit_BoolToInt.cs
+++ b/BenchmarkDotNet.Samples/Jit_BoolToInt.cs
@@ -41,10 +41,10 @@ namespace BenchmarkDotNet.Samples
             unsafe
             {
                 bool v1 = first;
-                int sum = *(int*)(&v1);
+                int sum = *(byte*)(&v1);
 
                 bool v2 = second;
-                sum += *(int*)(&v2);
+                sum += *(byte*)(&v2);
                 return sum;
             }
         }

--- a/BenchmarkDotNet.Samples/Program.cs
+++ b/BenchmarkDotNet.Samples/Program.cs
@@ -14,6 +14,7 @@
                 typeof(Jit_LoopUnrolling),
                 typeof(Jit_ArraySumLoopUnrolling),
                 typeof(Jit_Inlining),
+                typeof(Jit_BoolToInt),
                 typeof(Jit_Bce),
                 typeof(Jit_InterfaceMethod),
                 typeof(Cpu_Ilp_Inc),
@@ -27,6 +28,7 @@
                 typeof(Math_DoubleSqrt),
                 typeof(Math_DoubleSqrtAvx),
                 typeof(Algo_BitCount),
+                typeof(Algo_MostSignificantBit),
                 typeof(Algo_Md5VsSha256)
             });
             competitionSwitch.Run(args);

--- a/BenchmarkDotNet.sln
+++ b/BenchmarkDotNet.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.22823.1
+VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BenchmarkDotNet", "BenchmarkDotNet\BenchmarkDotNet.csproj", "{0F20FA04-52D8-4DB9-8B39-909125396A87}"
 EndProject
@@ -24,5 +24,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(CodealikeProperties) = postSolution
+		SolutionGuid = d2cbc5be-205d-41dd-a90d-d625822471e3
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
It appears that the JIT is quite bad at optimizing Convert.Int32(bool)


// BenchmarkDotNet=v0.7.6.0
// OS=Microsoft Windows NT 6.2.9200.0
// Processor=Intel(R) Core(TM) i5-2500K CPU @ 3.30GHz, ProcessorCount=4
// CLR=MS.NET 4.0.30319.42000, Arch=64-bit  [RyuJIT]
Common:  Type=Jit_BoolToInt  Mode=Throughput  Platform=X64  .NET=Current

        Method |       Jit |   AvrTime |   StdDev |       op/s |
-------------- |---------- |---------- |--------- |----------- |
     Framework | LegacyJit |   1.16 us | 28.20 ns |  858517.79 |
    IfThenElse | LegacyJit |   1.08 us | 44.58 ns |  929458.93 |
 UnsafeConvert | LegacyJit | 595.83 ns |  5.79 ns | 1678333.61 |
     Framework |    RyuJit |   1.31 us | 18.64 ns |  765539.56 |
    IfThenElse |    RyuJit |   1.31 us | 16.05 ns |  761023.73 |
 UnsafeConvert |    RyuJit | 896.80 ns |  6.27 ns | 1115078.04 |. 
