### PR TITLE
Reporting: use fixed precision for AvrTime and StdDev.

### DIFF
--- a/BenchmarkDotNet/Reports/BenchmarkTimeSpan.cs
+++ b/BenchmarkDotNet/Reports/BenchmarkTimeSpan.cs
@@ -14,21 +14,16 @@
 
         public override string ToString()
         {
-            if (Nanoseconds < 0.001)
-                return string.Format(EnvironmentHelper.MainCultureInfo, "{0:0.000000} ns", Nanoseconds);
-            if (Nanoseconds < 0.01)
-                return string.Format(EnvironmentHelper.MainCultureInfo, "{0:0.00000} ns", Nanoseconds);
-            if (Nanoseconds < 0.1)
-                return string.Format(EnvironmentHelper.MainCultureInfo, "{0:0.0000} ns", Nanoseconds);
-            if (Nanoseconds < 1)
-                return string.Format(EnvironmentHelper.MainCultureInfo, "{0:0.000} ns", Nanoseconds);
+            // Use fixed decimal precision for all numbers here so everything aligns nicely
+            // in the tabular reports. Four decimal places seems a good compromise.
+            // Note extra space between number and "s" to align that nicely too.
             if (Nanoseconds < 1000)
-                return string.Format(EnvironmentHelper.MainCultureInfo, "{0:0.00} ns", Nanoseconds);
+                return string.Format(EnvironmentHelper.MainCultureInfo, "{0:N4} ns", Nanoseconds);
             if (Microseconds < 1000)
-                return string.Format(EnvironmentHelper.MainCultureInfo, "{0:0.00} us", Microseconds);
+                return string.Format(EnvironmentHelper.MainCultureInfo, "{0:N4} us", Microseconds);
             if (Milliseconds < 1000)
-                return string.Format(EnvironmentHelper.MainCultureInfo, "{0:0.00} ms", Milliseconds);
-            return string.Format(EnvironmentHelper.MainCultureInfo, "{0:0.00} s", Seconds);
+                return string.Format(EnvironmentHelper.MainCultureInfo, "{0:N4} ms", Milliseconds);
+            return string.Format(EnvironmentHelper.MainCultureInfo, "{0:N4}  s", Seconds);
         }
     }
 }


### PR DESCRIPTION
- Makes report look much better with everything aligned;
- Four decimals is a good comporomise;
- Implemented using compile-time feature switch.

Sample:

```
 Method |    AvrTime |    StdDev |           op/s |
------- |----------- |---------- |--------------- |
 Sqrt13 | 60.7802 ns | 0.2933 ns |  16,452,713.42 |
 Sqrt14 |  1.6146 ns | 0.0162 ns | 619,364,025.60 |
```