### PR TITLE
Reporting: uniform time units across all benchmarks.

### DIFF
--- a/BenchmarkDotNet.Samples/BenchmarkDotNet.Samples.csproj
+++ b/BenchmarkDotNet.Samples/BenchmarkDotNet.Samples.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Intro_01_MethodTasks.cs" />
     <Compile Include="Intro_02_ClassTasks.cs" />
     <Compile Include="Cpu_Ilp_VsBce.cs" />
+    <Compile Include="Intro_04_UniformReportingTest.cs" />
     <Compile Include="Intro_03_SingleRun.cs" />
     <Compile Include="Jit_Bce.cs" />
     <Compile Include="Cpu_MatrixMultiplication.cs" />

--- a/BenchmarkDotNet.Samples/Intro_04_UniformReportingTest.cs
+++ b/BenchmarkDotNet.Samples/Intro_04_UniformReportingTest.cs
@@ -1,0 +1,80 @@
+﻿using BenchmarkDotNet.Tasks;
+
+namespace BenchmarkDotNet.Samples
+{
+    using System;
+    using System.Threading;
+
+    /// <summary>
+    /// A special benchmark to see that operation times are reported in uniform time units
+    /// and align nicely. These benchmarks produce widely different results but still we
+    /// should be able to compare them side-by-side without doing any mental translations
+    /// between nanoseconds to microseconds to milliseconds.
+    /// 
+    /// Expected output along these lines:
+    /// 
+    ///   Method |        AvrTime |      StdDev |       op/s |
+    /// -------- |--------------- |------------ |----------- |
+    ///  Slower1 |      1.8112 us |   0.2015 us | 552,120.14 |
+    ///  Slower2 |      2.4149 us |   0.2425 us | 414,095.82 |
+    ///  Slower3 |      9.0558 us |   0.3052 us | 110,426.47 |
+    ///  Slower4 |     81.2006 us |   1.2585 us |  12,315.18 |
+    ///  Slower5 |  4,148.1727 us | 740.3897 us |     241.07 |
+    ///  Slower6 | 15,047.0119 us |  99.5290 us |      66.46 |
+    /// 
+    /// As can be seen, all time units are microseconds, even though the two slowest of them
+    /// is in the milliseconds territory.
+    /// </summary>
+    [BenchmarkTask(mode: BenchmarkMode.SingleRun)]
+    public class Intro_04_UniformReportingTest
+    {
+        [Benchmark]
+        public void Slower1()
+        {
+            Iterate(5);
+        }
+
+        [Benchmark]
+        public void Slower2()
+        {
+            Iterate(100);
+        }
+
+        [Benchmark]
+        public void Slower3()
+        {
+            Iterate(1000);
+        }
+
+        [Benchmark]
+        public void Slower4()
+        {
+            Iterate(10000);
+        }
+
+        [Benchmark]
+        public void Slower5()
+        {
+            Iterate(500000);
+        }
+
+        [Benchmark]
+        public void Slower6()
+        {
+            Iterate(500000);
+            Thread.Sleep(10);
+        }
+
+        private static int[] Iterate(int arraySize)
+        {
+            var rand = new Random();
+            var array = new int[arraySize];
+            for (var i = 0; i < arraySize; i++)
+            {
+                array[i] = rand.Next();
+            }
+
+            return array;
+        }
+    }
+}

--- a/BenchmarkDotNet.Samples/Program.cs
+++ b/BenchmarkDotNet.Samples/Program.cs
@@ -9,6 +9,7 @@
                 typeof(Intro_01_MethodTasks),
                 typeof(Intro_02_ClassTasks),
                 typeof(Intro_03_SingleRun),
+                typeof(Intro_04_UniformReportingTest),
                 typeof(Il_ReadonlyFields),
                 typeof(Il_Switch),
                 typeof(Jit_LoopUnrolling),

--- a/BenchmarkDotNet/BenchmarkRunner.cs
+++ b/BenchmarkDotNet/BenchmarkRunner.cs
@@ -73,21 +73,16 @@ namespace BenchmarkDotNet
                     r.Benchmark,
                     Stat = new BenchmarkRunReportsStatistic("Target", r.Runs)
                 }).ToList();
+
+            // Ensure uniform number formats and use of time units via these helpers.
+            var averageTimeStats = reportStats.Select(reportStat => reportStat.Stat);
+            var timeToStringFunc = GetTimeMeasurementFormattingFunc(averageTimeStats);
+            var opsPerSecToStringFunc = GetOpsPerSecFormattingFunc();
+
             var table = new List<string[]> { new[] { "Type", "Method", "Mode", "Platform", "Jit", ".NET", "AvrTime", "StdDev", "op/s" } };
             foreach (var reportStat in reportStats)
             {
                 var b = reportStat.Benchmark;
-
-                // Ops/sec number formatting:
-                //      - Thousand separators: we generally expect large numbers so these 
-                //        would make it easier to view.
-                //      - Decimals: Do we really need these? Perhaps we do but only if we have
-                //        really small values to deal with.
-                // In any case, we would like to have all numbers to be aligned, ideally by decimal point
-                // but I'm too lazy to do that now, so maybe a compomise of fixed two decimals would do at the mo.
-                //
-                // Hence the choice of {N2} formatting string.
-                var opsPerSecValue = string.Format(EnvironmentHelper.MainCultureInfo, "{0:N2}", reportStat.Stat.OperationsPerSeconds.Median);
 
                 string[] row = {
                     b.Target.Type.Name,
@@ -96,9 +91,9 @@ namespace BenchmarkDotNet
                     b.Task.Configuration.Platform.ToString(),
                     b.Task.Configuration.JitVersion.ToString(),
                     b.Task.Configuration.Framework.ToString(),
-                    new BenchmarkTimeSpan(reportStat.Stat.AverageTime.Median).ToString(),
-                    new BenchmarkTimeSpan(reportStat.Stat.AverageTime.StandardDeviation).ToString(),
-                    opsPerSecValue
+                    timeToStringFunc(reportStat.Stat.AverageTime.Median),
+                    timeToStringFunc(reportStat.Stat.AverageTime.StandardDeviation),
+                    opsPerSecToStringFunc(reportStat.Stat.OperationsPerSeconds.Median)
                 };
                 table.Add(row);
             }
@@ -294,6 +289,77 @@ namespace BenchmarkDotNet
         {
             if (methodInfo.IsGenericMethod)
                 throw new InvalidOperationException($"Benchmark method {methodInfo.Name} is generic.\nGeneric benchmark methods are not supported.");
+        }
+
+        /// <summary>
+        /// Given a list of benchmark statistics creates a function to convert 
+        /// raw <see cref="AverageTime"/> measurements to string format so that they
+        /// are shown using uniform time units and align nicely.
+        /// The <see cref="AverageTime"/> measurements are assumed to contain time lengths in nanoseconds.
+        /// </summary>
+        /// <param name="statistics">The list of time-based <see cref="BenchmarkRunReportsStatistic"/>.</param>
+        /// <returns>A function which should be used to convert all <see cref="AverageTime"/> measurements to string.</returns>
+        /// <remarks>
+        /// The measurements are formatted in such a way that they use the same time unit 
+        /// the number of decimals so that they are easily comparable and align nicely.
+        /// 
+        /// Example:
+        /// Consider we have the following raw input where numbers are durations in nanoseconds: 
+        ///     Median=597855, StdErr=485;
+        ///     Median=7643, StdErr=87;
+        /// 
+        /// When using the formatting function, the output will be like this:
+        ///     597.8550 us, 0.0485 us;
+        ///       7.6430 us, 0.0087 us;
+        /// </remarks>
+        public static Func<double, string> GetTimeMeasurementFormattingFunc(IEnumerable<BenchmarkRunReportsStatistic> statistics)
+        {
+            // Find the smallest measurement in the primary statistics, which is the Median.
+            // This will determine the time unit we will use for all measurements.
+            var minRecordedMedian = statistics.Min(stat => stat.AverageTime.Median);
+
+            // Use the largest unit to display the smallest recorded measurement without loss of precision.
+            // TODO: This is duplicated in BenchmarkMeasurementStatistic.ToString(), figure out how to refactor this later?
+            Func<double, string> measurementToString;
+            if (minRecordedMedian < 1000)
+            {
+                measurementToString = (value) => string.Format(EnvironmentHelper.MainCultureInfo, "{0:N4} ns", value);
+            }
+            else if ((minRecordedMedian / 1000) < 1000)
+            {
+                measurementToString = (value) => string.Format(EnvironmentHelper.MainCultureInfo, "{0:N4} us", value / 1000);
+            }
+            else if ((minRecordedMedian / 1000 / 1000) < 1000)
+            {
+                measurementToString = (value) => string.Format(EnvironmentHelper.MainCultureInfo, "{0:N4} ms", value / 1000 / 1000);
+            }
+            else
+            {
+                measurementToString = (value) => string.Format(EnvironmentHelper.MainCultureInfo, "{0:N4}  s", value / 1000 / 1000 / 1000);
+            }
+
+            return measurementToString;
+        }
+
+        ///  <summary>
+        /// Given a list of benchmark statistics creates a function to convert 
+        /// raw <see cref="OperationsPerSeconds"/> measurements to string format so that they align nicely.
+        ///  </summary>
+        /// <returns>A function which should be used to convert all <see cref="OperationsPerSeconds"/> measurements to string.</returns>
+        /// <remarks>
+        ///  Ops/sec number formatting:
+        ///       - Thousand separators: we generally expect large numbers so these 
+        ///         would make it easier to view.
+        ///       - Decimals: Do we really need these? Perhaps we do but only if we have
+        ///         really small values to deal with.
+        ///  In any case, we would like to have all numbers to be aligned, ideally by decimal point
+        ///  but I'm too lazy to do that now, so maybe a compomise of fixed two decimals would do at the mo.
+        /// 
+        ///  Hence the choice of {N2} formatting string.
+        ///  </remarks>
+        public static Func<double, string> GetOpsPerSecFormattingFunc()
+        {
+            return (opsPerSec) => string.Format(EnvironmentHelper.MainCultureInfo, "{0:N2}", opsPerSec);
         }
     }
 }

--- a/BenchmarkDotNet/Reports/BenchmarkTimeSpan.cs
+++ b/BenchmarkDotNet/Reports/BenchmarkTimeSpan.cs
@@ -11,19 +11,5 @@
         {
             Nanoseconds = nanoseconds;
         }
-
-        public override string ToString()
-        {
-            // Use fixed decimal precision for all numbers here so everything aligns nicely
-            // in the tabular reports. Four decimal places seems a good compromise.
-            // Note extra space between number and "s" to align that nicely too.
-            if (Nanoseconds < 1000)
-                return string.Format(EnvironmentHelper.MainCultureInfo, "{0:N4} ns", Nanoseconds);
-            if (Microseconds < 1000)
-                return string.Format(EnvironmentHelper.MainCultureInfo, "{0:N4} us", Microseconds);
-            if (Milliseconds < 1000)
-                return string.Format(EnvironmentHelper.MainCultureInfo, "{0:N4} ms", Milliseconds);
-            return string.Format(EnvironmentHelper.MainCultureInfo, "{0:N4}  s", Seconds);
-        }
     }
 }


### PR DESCRIPTION
As per https://github.com/PerfDotNet/BenchmarkDotNet/issues/16

For usability use the same time unit when reporting `AvrTime` and `StdDev`.

Sample output:

```
  Method |        AvrTime |      StdDev |       op/s |
-------- |--------------- |------------ |----------- |
 Slower1 |      1.8112 us |   0.2015 us | 552,120.14 |
 Slower2 |      2.4149 us |   0.2425 us | 414,095.82 |
 Slower3 |      9.0558 us |   0.3052 us | 110,426.47 |
 Slower4 |     81.2006 us |   1.2585 us |  12,315.18 |
 Slower5 |  4,148.1727 us | 740.3897 us |     241.07 |
 Slower6 | 15,047.0119 us |  99.5290 us |      66.46 |
```