### PR TITLE
More examples also couldnt make CoreCLR to work on my machine. Check the example. 

### DIFF
--- a/BenchmarkDotNet.Samples/Algorithms/Algo_BitCount.cs
+++ b/BenchmarkDotNet.Samples/Algorithms/Algo_BitCount.cs
@@ -5,7 +5,7 @@ namespace BenchmarkDotNet.Samples.Algorithms
     // See http://en.wikipedia.org/wiki/Hamming_weight
     public class Algo_BitCount
     {
-        private const int N = 1001;
+        private const int N = 1002;
         private readonly ulong[] numbers;
         private readonly Random random = new Random(42);
 
@@ -47,6 +47,24 @@ namespace BenchmarkDotNet.Samples.Algorithms
             int counter = 0;
             for (int i = 0; i < N; i++)
                 counter += BitCountHelper.PopCount3(numbers[i]);
+            return counter;
+        }
+
+        [Benchmark]
+        public int PopCount4()
+        {
+            int counter = 0;
+            for (int i = 0; i < N; i++)
+                counter += BitCountHelper.PopCount4(numbers[i]);
+            return counter;
+        }
+
+        [Benchmark]
+        public int PopCountParallel2()
+        {
+            int counter = 0;
+            for (int i = 0; i < N / 2; i++)
+                counter += BitCountHelper.PopCountParallel2(numbers[i],numbers[i+1]);
             return counter;
         }
     }
@@ -103,6 +121,234 @@ namespace BenchmarkDotNet.Samples.Algorithms
             x = (x & m2) + ((x >> 2) & m2); //put count of each 4 bits into those 4 bits 
             x = (x + (x >> 4)) & m4;        //put count of each 8 bits into those 8 bits 
             return (int)((x * h01) >> 56);  //returns left 8 bits of x + (x<<8) + (x<<16) + (x<<24) + ... 
+        }
+
+        // This implementation uses branches to count. 
+        // Found at https://github.com/aspnet/KestrelHttpServer/blob/78de14d24868fd1b44a7335b30d9a2064c984516/src/Microsoft.AspNet.Server.Kestrel/Http/FrameHeaders.Generated.cs#L65
+        public static int PopCount4(ulong x)
+        {
+            int count = 0;
+
+            if (((x & 1L) != 0))
+            {
+                ++count;
+            }
+
+            if (((x & 2L) != 0))
+            {
+                ++count;
+            }
+
+            if (((x & 4L) != 0))
+            {
+                ++count;
+            }
+
+            if (((x & 8L) != 0))
+            {
+                ++count;
+            }
+
+            if (((x & 16L) != 0))
+            {
+                ++count;
+            }
+
+            if (((x & 32L) != 0))
+            {
+                ++count;
+            }
+
+            if (((x & 64L) != 0))
+            {
+                ++count;
+            }
+
+            if (((x & 128L) != 0))
+            {
+                ++count;
+            }
+
+            if (((x & 256L) != 0))
+            {
+                ++count;
+            }
+
+            if (((x & 512L) != 0))
+            {
+                ++count;
+            }
+
+            if (((x & 1024L) != 0))
+            {
+                ++count;
+            }
+
+            if (((x & 2048L) != 0))
+            {
+                ++count;
+            }
+
+            if (((x & 4096L) != 0))
+            {
+                ++count;
+            }
+
+            if (((x & 8192L) != 0))
+            {
+                ++count;
+            }
+
+            if (((x & 16384L) != 0))
+            {
+                ++count;
+            }
+
+            if (((x & 32768L) != 0))
+            {
+                ++count;
+            }
+
+            if (((x & 65536L) != 0))
+            {
+                ++count;
+            }
+
+            if (((x & 131072L) != 0))
+            {
+                ++count;
+            }
+
+            if (((x & 262144L) != 0))
+            {
+                ++count;
+            }
+
+            if (((x & 524288L) != 0))
+            {
+                ++count;
+            }
+
+            if (((x & 1048576L) != 0))
+            {
+                ++count;
+            }
+
+            if (((x & 2097152L) != 0))
+            {
+                ++count;
+            }
+
+            if (((x & 4194304L) != 0))
+            {
+                ++count;
+            }
+
+            if (((x & 8388608L) != 0))
+            {
+                ++count;
+            }
+
+            if (((x & 16777216L) != 0))
+            {
+                ++count;
+            }
+
+            if (((x & 33554432L) != 0))
+            {
+                ++count;
+            }
+
+            if (((x & 67108864L) != 0))
+            {
+                ++count;
+            }
+
+            if (((x & 134217728L) != 0))
+            {
+                ++count;
+            }
+
+            if (((x & 268435456L) != 0))
+            {
+                ++count;
+            }
+
+            if (((x & 536870912L) != 0))
+            {
+                ++count;
+            }
+
+            if (((x & 1073741824L) != 0))
+            {
+                ++count;
+            }
+
+            if (((x & 2147483648L) != 0))
+            {
+                ++count;
+            }
+
+            if (((x & 4294967296L) != 0))
+            {
+                ++count;
+            }
+
+            if (((x & 8589934592L) != 0))
+            {
+                ++count;
+            }
+
+            if (((x & 17179869184L) != 0))
+            {
+                ++count;
+            }
+
+            if (((x & 34359738368L) != 0))
+            {
+                ++count;
+            }
+
+            if (((x & 68719476736L) != 0))
+            {
+                ++count;
+            }
+
+            if (((x & 137438953472L) != 0))
+            {
+                ++count;
+            }
+
+            if (((x & 274877906944L) != 0))
+            {
+                ++count;
+            }
+
+            if (((x & 549755813888L) != 0))
+            {
+                ++count;
+            }
+
+            if (((x & 1099511627776L) != 0))
+            {
+                ++count;
+            }
+
+            return count;
+        }
+
+        public static int PopCountParallel2(ulong x, ulong y)
+        {
+            x -= (x >> 1) & m1;             //put count of each 2 bits into those 2 bits
+            y -= (y >> 1) & m1;             //put count of each 2 bits into those 2 bits
+
+            x = (x & m2) + ((x >> 2) & m2); //put count of each 4 bits into those 4 bits 
+            y = (y & m2) + ((y >> 2) & m2); //put count of each 4 bits into those 4 bits 
+
+            x = (x + (x >> 4)) & m4;        //put count of each 8 bits into those 8 bits                         
+            y = (y + (y >> 4)) & m4;        //put count of each 8 bits into those 8 bits 
+
+            return (int) ( ((y * h01) >> 56) + ((x * h01) >> 56) );  //returns left 8 bits of x + (x<<8) + (x<<16) + (x<<24) + ... 
         }
     }
 }

--- a/BenchmarkDotNet.Samples/BenchmarkDotNet.Samples.csproj
+++ b/BenchmarkDotNet.Samples/BenchmarkDotNet.Samples.csproj
@@ -69,6 +69,7 @@
     <Compile Include="JIT\Jit_Inlining.cs" />
     <Compile Include="JIT\Jit_InterfaceMethod.cs" />
     <Compile Include="JIT\Jit_LoopUnrolling.cs" />
+    <Compile Include="JIT\Jit_RotateBits.cs" />
     <Compile Include="Other\Array_HeapAllocVsStackAlloc.cs" />
     <Compile Include="Other\Math_DoubleSqrtAvx.cs" />
     <Compile Include="Other\Math_DoubleSqrt.cs" />

--- a/BenchmarkDotNet.Samples/JIT/Jit_RotateBits.cs
+++ b/BenchmarkDotNet.Samples/JIT/Jit_RotateBits.cs
@@ -11,22 +11,44 @@ namespace BenchmarkDotNet.Samples.JIT
     //[BenchmarkTask(platform: BenchmarkPlatform.X64, runtime: BenchmarkRuntime.CoreClr)]
     public class Jit_RotateBits
     {
-        private ulong a = 2340988;
-        private ulong b = 123444;
-        private ulong c = 1;
-        private ulong d = 23444111111;
+        private ulong au = 2340988;
+        private ulong bu = 123444;
+        private ulong cu = 1;
+        private ulong du = 23444111111;
+
+        private long ax = 2340988;
+        private long bx = 123444;
+        private long cx = 1;
+        private long dx = 23444111111;
 
         [Benchmark]
-        [OperationsPerInvoke(4)]        
-        public void RotateBits()
+        [OperationsPerInvoke(4)]
+        public void ShouldOptimize()
         {
-            RotateRight64(a, 16);
-            RotateRight64(b, 24);
-            RotateRight64(c, 32);
-            RotateRight64(d, 48);
+            RotateRight64(au, 16);
+            RotateRight64(bu, 24);
+            RotateRight64(cu, 32);
+            RotateRight64(du, 48);
         }
-        
+
+        [Benchmark]
+        [OperationsPerInvoke(4)]
+        public void ShouldNotOptimize()
+        {
+            RotateRight64(ax, 16);
+            RotateRight64(bx, 24);
+            RotateRight64(cx, 32);
+            RotateRight64(dx, 48);
+        }
+
         public static ulong RotateRight64(ulong value, int count)
+        {
+            return (value >> count) | (value << (64 - count));
+        }
+
+        /// This case should not be optimized because signed Right-Shift have special treatment for the negative case.
+        /// https://github.com/dotnet/coreclr/issues/1619#issuecomment-151609929
+        public static long RotateRight64(long value, int count)
         {
             return (value >> count) | (value << (64 - count));
         }

--- a/BenchmarkDotNet.Samples/JIT/Jit_RotateBits.cs
+++ b/BenchmarkDotNet.Samples/JIT/Jit_RotateBits.cs
@@ -1,0 +1,34 @@
+﻿using BenchmarkDotNet.Tasks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace BenchmarkDotNet.Samples.JIT
+{
+    [BenchmarkTask(platform: BenchmarkPlatform.X64, jitVersion: BenchmarkJitVersion.LegacyJit, runtime: BenchmarkRuntime.Default)]
+    //[BenchmarkTask(platform: BenchmarkPlatform.X64, runtime: BenchmarkRuntime.CoreClr)]
+    public class Jit_RotateBits
+    {
+        private ulong a = 2340988;
+        private ulong b = 123444;
+        private ulong c = 1;
+        private ulong d = 23444111111;
+
+        [Benchmark]
+        [OperationsPerInvoke(4)]        
+        public void RotateBits()
+        {
+            RotateRight64(a, 16);
+            RotateRight64(b, 24);
+            RotateRight64(c, 32);
+            RotateRight64(d, 48);
+        }
+        
+        public static ulong RotateRight64(ulong value, int count)
+        {
+            return (value >> count) | (value << (64 - count));
+        }
+    }
+}

--- a/BenchmarkDotNet.Samples/Program.cs
+++ b/BenchmarkDotNet.Samples/Program.cs
@@ -32,6 +32,7 @@ namespace BenchmarkDotNet.Samples
                 typeof(Jit_InterfaceMethod),
                 typeof(Jit_RegistersVsStack),
                 typeof(Jit_AsVsCast),
+                typeof(Jit_RotateBits),
                 // CPU
                 typeof(Cpu_Atomics),
                 typeof(Cpu_Ilp_Inc),


### PR DESCRIPTION
Added RotateBits will be interesting when https://github.com/dotnet/coreclr/issues/1619 is included in the Desktop RyuJIT and the CoreCLR runtime benchmarking works properly.

Added alternative implementations of PopCount for reference
 * Naive If based implementation
 * Parallel PopCount (two operations simultaneously avoiding data hazards).