### PR TITLE
Change Jit_GenericsMethod benchmark to reproduce on x64 both Legacy & RuyJit

### DIFF
--- a/BenchmarkDotNet.Samples/JIT/Jit_GenericsMethod.cs
+++ b/BenchmarkDotNet.Samples/JIT/Jit_GenericsMethod.cs
@@ -16,13 +16,13 @@ namespace BenchmarkDotNet.Samples.JIT
 
             public BaseClass()
             {
-                Enumerable.Empty<T>();
+                foreach (var _ in list) { }
             }
 
             public void Run()
             {
                 for (var i = 0; i < 11; i++)
-                    if (list.Any())
+                    if (list.Any(_ => true))
                         return;
             }
         }


### PR DESCRIPTION
That one reproduces on all platforms. Let's think about more concise repro and figure out what optimizations x64 performs comparing to x86 that the previous one didn't reproduce.