### PR TITLE
build fix: removing post build event that tried to copy non-existing dll

### DIFF
--- a/BenchmarkDotNet.IntegrationTests/BenchmarkDotNet.IntegrationTests.csproj
+++ b/BenchmarkDotNet.IntegrationTests/BenchmarkDotNet.IntegrationTests.csproj
@@ -101,9 +101,6 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
-  <PropertyGroup>
-    <PostBuildEvent>xcopy /F /Y $(ProjectDir)..\CLRMD\x86\msdia120.dll $(TargetDir)</PostBuildEvent>
-  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
I could not compile the solution due to lack of file that was copied in post build event.

I have checked and "CLRMD\x86\msdia120.dll" was never a part of the repo. But from what I see is that @mattwarren has added CLRMD folder with this post build event [recently](https://github.com/PerfDotNet/BenchmarkDotNet/commit/37f468db46c997d67f9ef3efe399bfe9a8e31b49). So Matt my question to you is whether you should add the missing file or is my fix ok?