### PR TITLE
Executing single Benchmark for multiple Runtimes

### DIFF
--- a/BenchmarkDotNet.IntegrationTests/MultipleRuntimesTest.cs
+++ b/BenchmarkDotNet.IntegrationTests/MultipleRuntimesTest.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Toolchains;
+using Xunit;
+
+namespace BenchmarkDotNet.IntegrationTests
+{
+    public class MultipleRuntimesTest
+    {
+        internal class AllRuntimesConfig : ManualConfig
+        {
+            public AllRuntimesConfig()
+            {
+                Add(Job.Dry.With(Runtime.Dnx).With(Jit.Host));
+                Add(Job.Dry.With(Runtime.Core).With(Jit.Host));
+                Add(Job.Dry.With(Runtime.Clr).With(Jit.Host).With(Framework.V45));
+            }
+        }
+
+        [Fact]
+        public void SingleBenchmarkCanBeExecutedForMultpleRuntimes()
+        {
+            var summary = BenchmarkRunner.Run<MultipleRuntimesTest>(new AllRuntimesConfig());
+
+            Assert.True(summary.Reports.Values.All(report => report.ExecuteResults.All(executeResult => executeResult.FoundExecutable)));
+            Assert.True(summary.Reports.Values.All(report => report.AllMeasurements.Any()));
+            Assert.True(summary.Reports.Values.Any(report => report.ExecuteResults.Any(executeResult => executeResult.Data.Contains("Classic"))));
+            Assert.True(summary.Reports.Values.Any(report => report.ExecuteResults.Any(executeResult => executeResult.Data.Contains("Dnx"))));
+            Assert.True(summary.Reports.Values.Any(report => report.ExecuteResults.Any(executeResult => executeResult.Data.Contains("Core"))));
+        }
+
+        [Benchmark]
+        public void Benchmark()
+        {
+            Console.WriteLine($"{Toolchain.GetToolchain(Runtime.Host)}");
+        }
+    }
+}

--- a/BenchmarkDotNet.Samples/Algorithms/Algo_Md5VsSha256.cs
+++ b/BenchmarkDotNet.Samples/Algorithms/Algo_Md5VsSha256.cs
@@ -1,9 +1,22 @@
 ﻿using System;
 using System.Security.Cryptography;
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
 
 namespace BenchmarkDotNet.Samples.Algorithms
 {
+    internal class AllRuntimesConfig : ManualConfig
+    {
+        public AllRuntimesConfig()
+        {
+            Add(Job.Default.With(Runtime.Dnx).With(Jit.Host));
+            Add(Job.Default.With(Runtime.Core).With(Jit.Host));
+            Add(Job.Default.With(Runtime.Clr).With(Jit.Host).With(Jobs.Framework.V40));
+        }
+    }
+
+    [Config(typeof(AllRuntimesConfig))]
     public class Algo_Md5VsSha256
     {
         private const int N = 10000;

--- a/BenchmarkDotNet.Samples/Intro/IntroRuntimes.cs
+++ b/BenchmarkDotNet.Samples/Intro/IntroRuntimes.cs
@@ -26,16 +26,17 @@ namespace BenchmarkDotNet.Samples.Intro
             }
         }
 
-        private class DnxAndCoreConfig : ManualConfig
+        private class MultipleRuntimesConfig : ManualConfig
         {
-            public DnxAndCoreConfig()
+            public MultipleRuntimesConfig()
             {
                 Add(Job.Dry.With(Runtime.Dnx).With(Jit.Host));
                 Add(Job.Dry.With(Runtime.Core).With(Jit.Host));
+                Add(Job.Dry.With(Runtime.Clr).With(Jit.Host).With(Jobs.Framework.V40));
             }
         }
 
-        [Config(typeof(DnxAndCoreConfig))]
+        [Config(typeof(MultipleRuntimesConfig))]
         public class IntroMultipleRuntimes
         {
             [Benchmark]

--- a/BenchmarkDotNet/Toolchains/Classic/ClassicToolchain.cs
+++ b/BenchmarkDotNet/Toolchains/Classic/ClassicToolchain.cs
@@ -1,13 +1,49 @@
-﻿#if CLASSIC
+﻿using System;
+using BenchmarkDotNet.Extensions;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Toolchains.DotNetCli;
+
 namespace BenchmarkDotNet.Toolchains.Classic
 {
     public class ClassicToolchain : Toolchain
     {
         public static readonly IToolchain Instance = new ClassicToolchain();
 
-        private ClassicToolchain() : base("Classic", new ClassicGenerator(), new ClassicBuilder(), new ClassicExecutor())
+        private ClassicToolchain()
+#if CLASSIC
+            : base("Classic", new ClassicGenerator(), new ClassicBuilder(), new ClassicExecutor())
+#else
+            : base("Classic", new DotNetCliGenerator(
+                      TargetFrameworkMonikerProvider,
+                      extraDependencies: "\"frameworkAssemblies\": { \"System.Runtime\": \"4.0.0.0\" }",
+                      platformProvider: platform => platform.ToConfig()),
+                  new DotNetCliBuilder(TargetFrameworkMonikerProvider),
+                  new ClassicExecutor())
+#endif
         {
+        }
+
+        private static string TargetFrameworkMonikerProvider(Framework framework)
+        {
+            switch (framework)
+            {
+                case Framework.Host:
+                    throw new ArgumentException("Framework must be set");
+                case Framework.V35:
+                    return "net35";
+                case Framework.V40:
+                    return "net40";
+                case Framework.V45:
+                    return "net45";
+                case Framework.V451:
+                    return "net451";
+                case Framework.V452:
+                    return "net452";
+                case Framework.V46:
+                    return "net46";
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(framework), framework, null);
+            }
         }
     }
 }
-#endif

--- a/BenchmarkDotNet/Toolchains/Core/CoreToolchain.cs
+++ b/BenchmarkDotNet/Toolchains/Core/CoreToolchain.cs
@@ -15,10 +15,10 @@ namespace BenchmarkDotNet.Toolchains.Core
         private CoreToolchain()
             : base("Core",
                   new DotNetCliGenerator(
-                      TargetFrameworkMoniker, 
+                      _ => TargetFrameworkMoniker, 
                       extraDependencies: "\"dependencies\": { \"NETStandard.Library\": \"1.0.0-rc2-23811\" }", // required by dotnet cli
                       platformProvider: _ => "x64"), // dotnet cli supports only x64 compilation now
-                  new DotNetCliBuilder(TargetFrameworkMoniker),
+                  new DotNetCliBuilder(_ => TargetFrameworkMoniker),
                   new ClassicExecutor())
         {
         }

--- a/BenchmarkDotNet/Toolchains/Dnx/DnxToolchain.cs
+++ b/BenchmarkDotNet/Toolchains/Dnx/DnxToolchain.cs
@@ -13,10 +13,10 @@ namespace BenchmarkDotNet.Toolchains.Dnx
         private DnxToolchain() 
             : base("Dnx",
                   new DotNetCliGenerator(
-                      TargetFrameworkMoniker,
+                      _ => TargetFrameworkMoniker,
                       extraDependencies: "\"frameworkAssemblies\": { \"System.Runtime\": \"4.0.10.0\" }",
                       platformProvider: platform => platform.ToConfig()),
-                  new DotNetCliBuilder(TargetFrameworkMoniker), 
+                  new DotNetCliBuilder(_ => TargetFrameworkMoniker), 
                   new ClassicExecutor())
         {
         }

--- a/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliBuilder.cs
+++ b/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Portability;
 using BenchmarkDotNet.Running;
@@ -16,11 +17,11 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
 
         private static readonly int DefaultTimeout = (int)TimeSpan.FromMinutes(2).TotalMilliseconds;
 
-        private string Framework { get; }
+        private Func<Framework, string> TargetFrameworkMonikerProvider { get; }
 
-        public DotNetCliBuilder(string framework)
+        public DotNetCliBuilder(Func<Framework, string> targetFrameworkMonikerProvider)
         {
-            Framework = framework;
+            TargetFrameworkMonikerProvider = targetFrameworkMonikerProvider;
         }
 
         /// <summary>
@@ -35,7 +36,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
             }
 
             if (!ExecuteCommand(
-                $"build --framework {Framework} --configuration {Configuration} --output {OutputDirectory}", 
+                $"build --framework {TargetFrameworkMonikerProvider(benchmark.Job.Framework)} --configuration {Configuration} --output {OutputDirectory}", 
                 generateResult.DirectoryPath, 
                 logger))
             {

--- a/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliGenerator.cs
+++ b/BenchmarkDotNet/Toolchains/DotNetCli/DotNetCliGenerator.cs
@@ -14,15 +14,15 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
     {
         private const string ProjectFileName = "project.json";
 
-        private string TargetFrameworkMoniker { get; }
+        private Func<Framework, string> TargetFrameworkMonikerProvider { get; }
 
         private string ExtraDependencies { get; }
 
         private Func<Platform, string> PlatformProvider { get; }
 
-        public DotNetCliGenerator(string targetFrameworkMoniker, string extraDependencies, Func<Platform, string> platformProvider)
+        public DotNetCliGenerator(Func<Framework, string> targetFrameworkMonikerProvider, string extraDependencies, Func<Platform, string> platformProvider)
         {
-            TargetFrameworkMoniker = targetFrameworkMoniker;
+            TargetFrameworkMonikerProvider = targetFrameworkMonikerProvider;
             ExtraDependencies = extraDependencies;
             PlatformProvider = platformProvider;
         }
@@ -45,7 +45,7 @@ namespace BenchmarkDotNet.Toolchains.DotNetCli
 
             var content = SetPlatform(template, PlatformProvider(benchmark.Job.Platform));
             content = SetDependencyToExecutingAssembly(content, benchmark.Target.Type);
-            content = SetTargetFrameworkMoniker(content, TargetFrameworkMoniker);
+            content = SetTargetFrameworkMoniker(content, TargetFrameworkMonikerProvider(benchmark.Job.Framework));
             content = SetExtraDependencies(content, ExtraDependencies);
 
             var projectJsonFilePath = Path.Combine(projectDir, ProjectFileName);

--- a/BenchmarkDotNet/Toolchains/Toolchain.cs
+++ b/BenchmarkDotNet/Toolchains/Toolchain.cs
@@ -36,9 +36,7 @@ namespace BenchmarkDotNet.Toolchains
                     return GetToolchain(RuntimeInformation.GetCurrent());
                 case Runtime.Clr:
                 case Runtime.Mono:
-#if CLASSIC
                     return Classic.ClassicToolchain.Instance;
-#endif
                 case Runtime.Dnx:
                     return Dnx.DnxToolchain.Instance;
                 case Runtime.Core:


### PR DESCRIPTION
We can use the advantages of xprojs and project.json files that allows targeting multiple frameworks and run single benchmark for multiple runtimes.

The mandatory thing is to set Framework for Runtime.Clr in explicit way. The app that contains the benchmarks must also be targeting all the frameworks. Just like BenchmarkDotNet.Samples does.

Sample config:
```
internal class AllRuntimesConfig : ManualConfig
{
	public AllRuntimesConfig()
	{
		Add(Job.Default.With(Runtime.Dnx).With(Jit.Host));
		Add(Job.Default.With(Runtime.Core).With(Jit.Host));
		Add(Job.Default.With(Runtime.Clr).With(Jit.Host).With(Jobs.Framework.V40));
	}
}
```

Sample results:
![image](https://cloud.githubusercontent.com/assets/6011991/13699089/78ab047c-e778-11e5-9218-3bc274f25d02.png)