### PR TITLE
Percentiles added into Statistics, StatisticColumn, BaselineDiffColumn

### DIFF
--- a/BenchmarkDotNet.Tests/StatisticsTests.cs
+++ b/BenchmarkDotNet.Tests/StatisticsTests.cs
@@ -128,5 +128,36 @@ namespace BenchmarkDotNet.Tests
             Assert.Equal(12.34974, summary.ConfidenceInterval.Lower, 4);
             Assert.Equal(18.65026, summary.ConfidenceInterval.Upper, 4);
         }
+
+        [Fact]
+        public void PercentileValuesTest()
+        {
+            var summary = new Statistics(Enumerable.Range(1, 30));
+            Print(summary);
+            Assert.Equal(1, summary.Percentiles.P0);
+            Assert.Equal(8.25, summary.Percentiles.P25);
+            Assert.Equal(15.5, summary.Percentiles.P50);
+            Assert.Equal(20.3333, summary.Percentiles.P67, 4);
+            Assert.Equal(24.2, summary.Percentiles.P80, 4);
+            Assert.Equal(25.65, summary.Percentiles.P85);
+            Assert.Equal(27.1, summary.Percentiles.P90);
+            Assert.Equal(28.55, summary.Percentiles.P95, 4);
+            Assert.Equal(30, summary.Percentiles.P100);
+
+            var a = Enumerable.Range(1, 30);
+            var b = Enumerable.Concat(Enumerable.Repeat(0, 30), a);
+            var c = Enumerable.Concat(b, Enumerable.Repeat(31, 30));
+            summary = new Statistics(c);
+            Print(summary);
+            Assert.Equal(0, summary.Percentiles.P0);
+            Assert.Equal(0, summary.Percentiles.P25);
+            Assert.Equal(15.5, summary.Percentiles.P50);
+            Assert.Equal(30.3333, summary.Percentiles.P67, 4);
+            Assert.Equal(31, summary.Percentiles.P80);
+            Assert.Equal(31, summary.Percentiles.P85);
+            Assert.Equal(31, summary.Percentiles.P90);
+            Assert.Equal(31, summary.Percentiles.P95);
+            Assert.Equal(31, summary.Percentiles.P100);
+        }
     }
 }

--- a/BenchmarkDotNet.Tests/StatisticsTests.cs
+++ b/BenchmarkDotNet.Tests/StatisticsTests.cs
@@ -137,7 +137,7 @@ namespace BenchmarkDotNet.Tests
             Assert.Equal(1, summary.Percentiles.P0);
             Assert.Equal(8.25, summary.Percentiles.P25);
             Assert.Equal(15.5, summary.Percentiles.P50);
-            Assert.Equal(20.3333, summary.Percentiles.P67, 4);
+            Assert.Equal(20.43, summary.Percentiles.P67, 4);
             Assert.Equal(24.2, summary.Percentiles.P80, 4);
             Assert.Equal(25.65, summary.Percentiles.P85);
             Assert.Equal(27.1, summary.Percentiles.P90);
@@ -152,7 +152,7 @@ namespace BenchmarkDotNet.Tests
             Assert.Equal(0, summary.Percentiles.P0);
             Assert.Equal(0, summary.Percentiles.P25);
             Assert.Equal(15.5, summary.Percentiles.P50);
-            Assert.Equal(30.3333, summary.Percentiles.P67, 4);
+            Assert.Equal(30.63, summary.Percentiles.P67, 4);
             Assert.Equal(31, summary.Percentiles.P80);
             Assert.Equal(31, summary.Percentiles.P85);
             Assert.Equal(31, summary.Percentiles.P90);

--- a/BenchmarkDotNet/Columns/BaselineDiffColumn.cs
+++ b/BenchmarkDotNet/Columns/BaselineDiffColumn.cs
@@ -17,20 +17,22 @@ namespace BenchmarkDotNet.Columns
 
         public static readonly IColumn Delta = new BaselineDiffColumn(DiffKind.Delta);
         public static readonly IColumn Scaled = new BaselineDiffColumn(DiffKind.Scaled);
-        public static readonly IColumn Scaled50 = new BaselineDiffColumn(DiffKind.Scaled, PercentileLevel.P50);
-        public static readonly IColumn Scaled85 = new BaselineDiffColumn(DiffKind.Scaled, PercentileLevel.P85);
-        public static readonly IColumn Scaled95 = new BaselineDiffColumn(DiffKind.Scaled, PercentileLevel.P95);
+        public static readonly IColumn Scaled50 = new BaselineDiffColumn(DiffKind.Scaled, 50);
+        public static readonly IColumn Scaled85 = new BaselineDiffColumn(DiffKind.Scaled, 85);
+        public static readonly IColumn Scaled95 = new BaselineDiffColumn(DiffKind.Scaled, 95);
 
         public DiffKind Kind { get; set; }
-        public PercentileLevel? Percentile { get; set; }
+        public int? Percentile { get; set; }
 
-        private BaselineDiffColumn(DiffKind kind, PercentileLevel? percentile = null)
+        private BaselineDiffColumn(DiffKind kind, int? percentile = null)
         {
             Kind = kind;
             Percentile = percentile;
         }
 
-        public string ColumnName => Kind.ToString() + Percentile?.ToString();
+        public string ColumnName => Percentile == null ?
+            Kind.ToString() :
+            Kind.ToString() + "P" + Percentile?.ToString();
 
         public string GetValue(Summary summary, Benchmark benchmark)
         {
@@ -59,10 +61,10 @@ namespace BenchmarkDotNet.Columns
                 case DiffKind.Delta:
                     if (benchmark.Target.Baseline)
                         return "Baseline";
-                    var diff = (currentMetric - baselineMetric)/baselineMetric*100.0;
+                    var diff = (currentMetric - baselineMetric) / baselineMetric * 100.0;
                     return diff.ToStr("N1") + "%";
                 case DiffKind.Scaled:
-                    var scale = currentMetric/baselineMetric;
+                    var scale = currentMetric / baselineMetric;
                     return scale.ToStr("N2");
                 default:
                     return "?";

--- a/BenchmarkDotNet/Columns/StatisticColumn.cs
+++ b/BenchmarkDotNet/Columns/StatisticColumn.cs
@@ -21,6 +21,16 @@ namespace BenchmarkDotNet.Columns
         public static readonly IColumn Q3 = new StatisticColumn("Q3", s => s.Q3);
         public static readonly IColumn Max = new StatisticColumn("Max", s => s.Max);
 
+        public static readonly IColumn P0 = new StatisticColumn("P0", s => s.Percentiles.P0);
+        public static readonly IColumn P25 = new StatisticColumn("P25", s => s.Percentiles.P25);
+        public static readonly IColumn P50 = new StatisticColumn("P50", s => s.Percentiles.P50);
+        public static readonly IColumn P67 = new StatisticColumn("P67", s => s.Percentiles.P67);
+        public static readonly IColumn P80 = new StatisticColumn("P80", s => s.Percentiles.P80);
+        public static readonly IColumn P85 = new StatisticColumn("P85", s => s.Percentiles.P85);
+        public static readonly IColumn P90 = new StatisticColumn("P90", s => s.Percentiles.P90);
+        public static readonly IColumn P95 = new StatisticColumn("P95", s => s.Percentiles.P95);
+        public static readonly IColumn P100 = new StatisticColumn("P100", s => s.Percentiles.P100);
+
         public static IColumn CiLower(ConfidenceLevel level) => new StatisticColumn($"CI {level.ToPercent()}% Lower",
             s => new ConfidenceInterval(s.Mean, s.StandardError, level).Lower);
         public static IColumn CiUpper(ConfidenceLevel level) => new StatisticColumn($"CI {level.ToPercent()}% Upper",

--- a/BenchmarkDotNet/Mathematics/PercentileValues.cs
+++ b/BenchmarkDotNet/Mathematics/PercentileValues.cs
@@ -6,29 +6,6 @@ using BenchmarkDotNet.Reports;
 
 namespace BenchmarkDotNet.Mathematics
 {
-    public enum PercentileLevel : int
-    {
-        P0 = 0,
-        P25 = 25,
-        P50 = 50,
-        P67 = 67,
-        P80 = 80,
-        P85 = 85,
-        P90 = 90,
-        P95 = 95,
-        P100 = 100
-    }
-
-    public static class PercentileLevelExtensions
-    {
-        public static double ToRatio(this PercentileLevel level)
-        {
-            return level == PercentileLevel.P67 ?
-                 2.0 / 3.0 :
-                 (int)level / 100.0;
-        }
-    }
-
     public class PercentileValues
     {
         /// <summary>
@@ -40,18 +17,18 @@ namespace BenchmarkDotNet.Mathematics
         /// And it's a good idea to have same results from all tools being used.
         /// </remarks>
         /// <param name="values">Sequence of the values to be calculated</param>
-        /// <param name="percentileRatio">Value in range 0.0..1.0</param>
+        /// <param name="percentile">Value in range 0..100</param>
         /// <returns>Percentile from the set of values</returns>
         // BASEDON: http://stackoverflow.com/a/8137526
-        private static double Percentile(List<double> sortedValues, double percentileRatio)
+        private static double Percentile(List<double> sortedValues, int percentile)
         {
             if (sortedValues == null)
                 throw new ArgumentNullException(nameof(sortedValues));
-            if (percentileRatio < 0 || percentileRatio > 1)
+            if (percentile < 0 || percentile > 100)
             {
                 throw new ArgumentOutOfRangeException(
-                     nameof(percentileRatio), percentileRatio,
-                     "The percentileRatio arg should be in range of 0.0 - 1.0.");
+                     nameof(percentile), percentile,
+                     "The percentile arg should be in range of 0 - 100.");
             }
 
             if (sortedValues.Count == 0)
@@ -60,7 +37,7 @@ namespace BenchmarkDotNet.Mathematics
             // DONTTOUCH: the following code was taken from http://stackoverflow.com/a/8137526 and it is proven
             // to work in the same way the excel's counterpart does.
             // So it's better to leave it as it is unless you do not want to reimplement it from scratch:)
-            double realIndex = percentileRatio * (sortedValues.Count - 1);
+            double realIndex = percentile / 100.0 * (sortedValues.Count - 1);
             int index = (int)realIndex;
             double frac = realIndex - index;
             if (index + 1 < sortedValues.Count)
@@ -69,8 +46,7 @@ namespace BenchmarkDotNet.Mathematics
                 return sortedValues[index];
         }
 
-        public double Percentile(double ratio) => Percentile(SortedValues, ratio);
-        public double Percentile(PercentileLevel percentileLevel) => Percentile(SortedValues, percentileLevel.ToRatio());
+        public double Percentile(int percentile) => Percentile(SortedValues, percentile);
 
         private List<double> SortedValues { get; }
 
@@ -87,16 +63,17 @@ namespace BenchmarkDotNet.Mathematics
         internal PercentileValues(List<double> sortedValues)
         {
             SortedValues = sortedValues;
+
             // TODO: Collect all in one call?
-            P0 = Percentile(PercentileLevel.P0);
-            P25 = Percentile(PercentileLevel.P25);
-            P50 = Percentile(PercentileLevel.P50);
-            P67 = Percentile(PercentileLevel.P67);
-            P80 = Percentile(PercentileLevel.P80);
-            P85 = Percentile(PercentileLevel.P85);
-            P90 = Percentile(PercentileLevel.P90);
-            P95 = Percentile(PercentileLevel.P95);
-            P100 = Percentile(PercentileLevel.P100);
+            P0 = Percentile(0);
+            P25 = Percentile(25);
+            P50 = Percentile(50);
+            P67 = Percentile(67);
+            P80 = Percentile(80);
+            P85 = Percentile(85);
+            P90 = Percentile(90);
+            P95 = Percentile(95);
+            P100 = Percentile(100);
         }
 
         public string ToStr(bool showLevel = true) => $"[.95: {P95.ToStr()}] (0: {P0.ToStr()}]; .5: {P50.ToStr()}; 1: {P100.ToStr()})";

--- a/BenchmarkDotNet/Mathematics/PercentileValues.cs
+++ b/BenchmarkDotNet/Mathematics/PercentileValues.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+using BenchmarkDotNet.Extensions;
+using BenchmarkDotNet.Horology;
+using BenchmarkDotNet.Reports;
+
+namespace BenchmarkDotNet.Mathematics
+{
+    public enum PercentileLevel : int
+    {
+        P0 = 0,
+        P25 = 25,
+        P50 = 50,
+        P67 = 67,
+        P80 = 80,
+        P85 = 85,
+        P90 = 90,
+        P95 = 95,
+        P100 = 100
+    }
+
+    public static class PercentileLevelExtensions
+    {
+        public static double ToRatio(this PercentileLevel level)
+        {
+            return level == PercentileLevel.P67 ?
+                 2.0 / 3.0 :
+                 (int)level / 100.0;
+        }
+    }
+
+    public class PercentileValues
+    {
+        /// <summary>
+        /// Calculates the Nth percentile from the set of values
+        /// </summary>
+        /// <remarks>
+        /// The implementation is expected to be consitent with the one from Excel.
+        /// It's a quite common to export bench output into .csv for further analysis 
+        /// And it's a good idea to have same results from all tools being used.
+        /// </remarks>
+        /// <param name="values">Sequence of the values to be calculated</param>
+        /// <param name="percentileRatio">Value in range 0.0..1.0</param>
+        /// <returns>Percentile from the set of values</returns>
+        // BASEDON: http://stackoverflow.com/a/8137526
+        private static double Percentile(List<double> sortedValues, double percentileRatio)
+        {
+            if (sortedValues == null)
+                throw new ArgumentNullException(nameof(sortedValues));
+            if (percentileRatio < 0 || percentileRatio > 1)
+            {
+                throw new ArgumentOutOfRangeException(
+                     nameof(percentileRatio), percentileRatio,
+                     "The percentileRatio arg should be in range of 0.0 - 1.0.");
+            }
+
+            if (sortedValues.Count == 0)
+                return 0;
+
+            // DONTTOUCH: the following code was taken from http://stackoverflow.com/a/8137526 and it is proven
+            // to work in the same way the excel's counterpart does.
+            // So it's better to leave it as it is unless you do not want to reimplement it from scratch:)
+            double realIndex = percentileRatio * (sortedValues.Count - 1);
+            int index = (int)realIndex;
+            double frac = realIndex - index;
+            if (index + 1 < sortedValues.Count)
+                return sortedValues[index] * (1 - frac) + sortedValues[index + 1] * frac;
+            else
+                return sortedValues[index];
+        }
+
+        public double Percentile(double ratio) => Percentile(SortedValues, ratio);
+        public double Percentile(PercentileLevel percentileLevel) => Percentile(SortedValues, percentileLevel.ToRatio());
+
+        private List<double> SortedValues { get; }
+
+        public double P0 { get; }
+        public double P25 { get; }
+        public double P50 { get; }
+        public double P67 { get; }
+        public double P80 { get; }
+        public double P85 { get; }
+        public double P90 { get; }
+        public double P95 { get; }
+        public double P100 { get; }
+
+        internal PercentileValues(List<double> sortedValues)
+        {
+            SortedValues = sortedValues;
+            // TODO: Collect all in one call?
+            P0 = Percentile(PercentileLevel.P0);
+            P25 = Percentile(PercentileLevel.P25);
+            P50 = Percentile(PercentileLevel.P50);
+            P67 = Percentile(PercentileLevel.P67);
+            P80 = Percentile(PercentileLevel.P80);
+            P85 = Percentile(PercentileLevel.P85);
+            P90 = Percentile(PercentileLevel.P90);
+            P95 = Percentile(PercentileLevel.P95);
+            P100 = Percentile(PercentileLevel.P100);
+        }
+
+        public string ToStr(bool showLevel = true) => $"[.95: {P95.ToStr()}] (0: {P0.ToStr()}]; .5: {P50.ToStr()}; 1: {P100.ToStr()})";
+        public string ToTimeStr(TimeUnit unit = null, bool showLevel = true) => $"[.95: {P95.ToTimeStr(unit)}] (0: {P0.ToTimeStr(unit)}]; .5: {P50.ToTimeStr(unit)}; 1: {P100.ToTimeStr(unit)})";
+    }
+}

--- a/BenchmarkDotNet/Mathematics/Statistics.cs
+++ b/BenchmarkDotNet/Mathematics/Statistics.cs
@@ -22,6 +22,7 @@ namespace BenchmarkDotNet.Mathematics
         public double StandardError { get; }
         public double StandardDeviation { get; }
         public ConfidenceInterval ConfidenceInterval { get; }
+        public PercentileValues Percentiles { get; }
 
         public Statistics(params double[] values) :
             this(values.ToList())
@@ -66,6 +67,7 @@ namespace BenchmarkDotNet.Mathematics
             StandardDeviation = N == 1 ? 0 : Math.Sqrt(list.Sum(d => Math.Pow(d - Mean, 2)) / (N - 1));
             StandardError = StandardDeviation / Math.Sqrt(N);
             ConfidenceInterval = new ConfidenceInterval(Mean, StandardError);
+            Percentiles = new PercentileValues(list);
         }
 
         public bool IsOutlier(double value) => value < LowerFence || value > UpperFence;


### PR DESCRIPTION
Redone as #164. This one will be closed

As I wrote [here](https://github.com/PerfDotNet/BenchmarkDotNet/issues/126#issuecomment-200302063) I begin to do small PR to make it easier to use BenchmarkDotNet as an competition tests runner.

This PR adds Nth percentile and Nth percenile scaled columns. These should be used to rank and to compare competitors if the timings are varying from run to run.

More info on these: 
http://www.goland.org/average_percentile_services/
http://apmblog.dynatrace.com/2012/11/14/why-averages-suck-and-percentiles-are-great/

P.S. I'm not sure that proposed API design is good enough so it's definitely subject to discuss:)