### PR TITLE
Percentiles added into Statistics, StatisticColumn, BaselineDiffColumn

### DIFF
--- a/BenchmarkDotNet.IntegrationTests/BaselineDiffColumnTest.cs
+++ b/BenchmarkDotNet.IntegrationTests/BaselineDiffColumnTest.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using BenchmarkDotNet.Jobs;
+using System;
 using System.Linq;
 using System.Threading;
 using Xunit;
@@ -8,6 +9,8 @@ using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Exporters;
+using BenchmarkDotNet.Extensions;
+using BenchmarkDotNet.Helpers;
 using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Running;
 
@@ -166,5 +169,65 @@ namespace BenchmarkDotNet.IntegrationTests
             // and https://github.com/PerfDotNet/BenchmarkDotNet/issues/158
             throw new InvalidOperationException("Part of a Unit test - This is expected");
         }
+    }
+
+    [Config(typeof(SingleRunFastConfig))]
+    public class BaselineScaledColumnsTest
+    {
+        [Params(1, 2)]
+        public int ParamProperty { get; set; }
+
+        [Fact]
+        public void Test()
+        {
+            // This is the common way to run benchmarks, it should wire up the BenchmarkBaselineDeltaResultExtender for us
+            var config = DefaultConfig.Instance
+                .With(BaselineDiffColumn.Scaled50)
+                .With(BaselineDiffColumn.Scaled85)
+                .With(BaselineDiffColumn.Scaled95);
+            var summary = BenchmarkRunner.Run(this.GetType(), config);
+
+            var table = summary.Table;
+            var headerRow = table.FullHeader;
+            var columns = summary.Config.GetColumns().OfType<BaselineDiffColumn>().ToArray();
+            Assert.Equal(columns.Length, 4);
+
+            Assert.Equal(columns[0].ColumnName, headerRow[headerRow.Length - 4]);
+            Assert.Equal(columns[1].ColumnName, headerRow[headerRow.Length - 3]);
+            Assert.Equal(columns[2].ColumnName, headerRow[headerRow.Length - 2]);
+            Assert.Equal(columns[3].ColumnName, headerRow[headerRow.Length - 1]);
+
+            var testNameColumn = Array.FindIndex(headerRow, c => c == "Method");
+            var parseCulture = EnvironmentInfo.MainCultureInfo;
+            foreach (var row in table.FullContent)
+            {
+                Assert.Equal(row.Length, headerRow.Length);
+                if (row[testNameColumn] == "BenchmarkFast") // This is our baseline
+                {
+                    Assert.Equal("1.00", row[headerRow.Length - 4]); // Scaled
+                    Assert.Equal("1.00", row[headerRow.Length - 3]); // S50
+                    Assert.Equal("1.00", row[headerRow.Length - 2]); // S85
+                    Assert.Equal("1.00", row[headerRow.Length - 1]); // S95
+                }
+                else if (row[testNameColumn] == "BenchmarkSlow") // This should have been compared to the baseline
+                {
+                    var scaled = double.Parse(row[headerRow.Length - 4], parseCulture);
+                    Assert.InRange(scaled, 3.7, 4.3);
+                    var s50 = double.Parse(row[headerRow.Length - 3], parseCulture);
+                    Assert.InRange(s50, 3.7, 4.3);
+                    var s85 = double.Parse(row[headerRow.Length - 2], parseCulture);
+                    Assert.InRange(s85, 3.7, 4.3);
+                    var s95 = double.Parse(row[headerRow.Length - 1], parseCulture);
+                    Assert.InRange(s95, 3.7, 4.3);
+                }
+            }
+        }
+
+        [Benchmark(Baseline = true)]
+        public void BenchmarkFast() => Thread.Sleep(5);
+
+        [Benchmark]
+        public void BenchmarkSlow() => Thread.Sleep(20);
+
     }
 }

--- a/BenchmarkDotNet.IntegrationTests/StatResultExtenderTests.cs
+++ b/BenchmarkDotNet.IntegrationTests/StatResultExtenderTests.cs
@@ -32,7 +32,10 @@ namespace BenchmarkDotNet.IntegrationTests
                 StatisticColumn.Median,
                 StatisticColumn.Q3,
                 StatisticColumn.Max,
-                StatisticColumn.OperationsPerSecond
+                StatisticColumn.OperationsPerSecond,
+				StatisticColumn.P85,
+				StatisticColumn.P95,
+				StatisticColumn.P95
             };
             var config = DefaultConfig.Instance.With(logger).With(columns);
             var summary = BenchmarkRunner.Run<Target>(config);

--- a/BenchmarkDotNet.Samples/Intro/IntroPercentiles.cs
+++ b/BenchmarkDotNet.Samples/Intro/IntroPercentiles.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Threading;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Attributes;
+
+namespace BenchmarkDotNet.Samples.Intro
+{
+    // Using percentiles for adequate timings representation
+    [Config(typeof(Config))]
+    public class IntroPercentiles
+    {
+        // To share between runs.
+        // DO NOT do this in production code. The System.Random IS NOT threadsafe.
+        private static readonly Random rnd = new Random();
+
+        private class Config : ManualConfig
+        {
+            public Config()
+            {
+                Add(new Job
+                {
+                    Mode = Mode.SingleRun,
+                    LaunchCount = 4,
+                    WarmupCount = 3,
+                    TargetCount = 20
+                });
+                Add(
+                    StatisticColumn.P0,
+                    StatisticColumn.P25,
+                    StatisticColumn.P50,
+                    StatisticColumn.P67,
+                    StatisticColumn.P80,
+                    StatisticColumn.P85,
+                    StatisticColumn.P90,
+                    StatisticColumn.P95,
+                    StatisticColumn.P100,
+                    BaselineDiffColumn.Scaled50,
+                    BaselineDiffColumn.Scaled85,
+                    BaselineDiffColumn.Scaled95);
+            }
+        }
+
+        [Benchmark(Baseline = true)]
+        public void ConstantDelays()
+        {
+            Thread.Sleep(20);
+        }
+
+        [Benchmark]
+        public void RandomDelays()
+        {
+            Thread.Sleep(10 + (int)(20 * rnd.NextDouble()));
+        }
+
+        [Benchmark]
+        public void RareDelays()
+        {
+            var rndTime = 10;
+            // Bigger delays for 15% of the runs
+            if (rnd.NextDouble() > 0.85)
+            {
+                rndTime += 30;
+            }
+            Thread.Sleep(rndTime);
+        }
+    }
+}

--- a/BenchmarkDotNet.Tests/StatisticsTests.cs
+++ b/BenchmarkDotNet.Tests/StatisticsTests.cs
@@ -29,6 +29,7 @@ namespace BenchmarkDotNet.Tests
             output.WriteLine("StandardDeviation = " + summary.StandardDeviation);
             output.WriteLine("Outlier = [" + string.Join("; ", summary.Outliers) + "]");
             output.WriteLine("CI = " + summary.ConfidenceInterval.ToStr());
+            output.WriteLine("Percentiles = " + summary.Percentiles.ToStr());
         }
 
         [Fact]
@@ -53,6 +54,12 @@ namespace BenchmarkDotNet.Tests
             Assert.Equal(0, summary.InterquartileRange);
             Assert.Equal(0, summary.StandardDeviation);
             Assert.Equal(new double[0], summary.Outliers);
+            Assert.Equal(1, summary.Percentiles.P0);
+            Assert.Equal(1, summary.Percentiles.P25);
+            Assert.Equal(1, summary.Percentiles.P50);
+            Assert.Equal(1, summary.Percentiles.P85);
+            Assert.Equal(1, summary.Percentiles.P95);
+            Assert.Equal(1, summary.Percentiles.P100);
         }
 
         [Fact]
@@ -71,6 +78,12 @@ namespace BenchmarkDotNet.Tests
             Assert.Equal(1, summary.InterquartileRange);
             Assert.Equal(0.70711, summary.StandardDeviation, 4);
             Assert.Equal(new double[0], summary.Outliers);
+			Assert.Equal(1, summary.Percentiles.P0);
+			Assert.Equal(1.25, summary.Percentiles.P25);
+			Assert.Equal(1.5, summary.Percentiles.P50);
+			Assert.Equal(1.85, summary.Percentiles.P85);
+			Assert.Equal(1.95, summary.Percentiles.P95);
+			Assert.Equal(2, summary.Percentiles.P100);
         }
 
         [Fact]
@@ -89,6 +102,12 @@ namespace BenchmarkDotNet.Tests
             Assert.Equal(3, summary.InterquartileRange);
             Assert.Equal(1.52753, summary.StandardDeviation, 4);
             Assert.Equal(new double[0], summary.Outliers);
+			Assert.Equal(1, summary.Percentiles.P0);
+			Assert.Equal(1.5, summary.Percentiles.P25);
+			Assert.Equal(2, summary.Percentiles.P50);
+			Assert.Equal(3.4, summary.Percentiles.P85);
+			Assert.Equal(3.8, summary.Percentiles.P95);
+			Assert.Equal(4, summary.Percentiles.P100);
         }
 
         [Fact]
@@ -107,6 +126,12 @@ namespace BenchmarkDotNet.Tests
             Assert.Equal(30, summary.InterquartileRange);
             Assert.Equal(22.9378, summary.StandardDeviation, 4);
             Assert.Equal(new double[0], summary.Outliers);
+			Assert.Equal(1, summary.Percentiles.P0);
+			Assert.Equal(3, summary.Percentiles.P25);
+			Assert.Equal(8, summary.Percentiles.P50);
+			Assert.Equal(35.2, summary.Percentiles.P85, 4);
+			Assert.Equal(54.4, summary.Percentiles.P95, 4);
+			Assert.Equal(64, summary.Percentiles.P100);
         }
 
         [Fact]
@@ -127,6 +152,37 @@ namespace BenchmarkDotNet.Tests
             Assert.Equal(summary.StandardError, summary.ConfidenceInterval.Error);
             Assert.Equal(12.34974, summary.ConfidenceInterval.Lower, 4);
             Assert.Equal(18.65026, summary.ConfidenceInterval.Upper, 4);
+        }
+
+        [Fact]
+        public void PercentileValuesTest()
+        {
+            var summary = new Statistics(Enumerable.Range(1, 30));
+            Print(summary);
+            Assert.Equal(1, summary.Percentiles.P0);
+            Assert.Equal(8.25, summary.Percentiles.P25);
+            Assert.Equal(15.5, summary.Percentiles.P50);
+            Assert.Equal(20.43, summary.Percentiles.P67, 4);
+            Assert.Equal(24.2, summary.Percentiles.P80, 4);
+            Assert.Equal(25.65, summary.Percentiles.P85);
+            Assert.Equal(27.1, summary.Percentiles.P90);
+            Assert.Equal(28.55, summary.Percentiles.P95, 4);
+            Assert.Equal(30, summary.Percentiles.P100);
+
+            var a = Enumerable.Range(1, 30);
+            var b = Enumerable.Concat(Enumerable.Repeat(0, 30), a);
+            var c = Enumerable.Concat(b, Enumerable.Repeat(31, 30));
+            summary = new Statistics(c);
+            Print(summary);
+            Assert.Equal(0, summary.Percentiles.P0);
+            Assert.Equal(0, summary.Percentiles.P25);
+            Assert.Equal(15.5, summary.Percentiles.P50);
+            Assert.Equal(30.63, summary.Percentiles.P67, 4);
+            Assert.Equal(31, summary.Percentiles.P80);
+            Assert.Equal(31, summary.Percentiles.P85);
+            Assert.Equal(31, summary.Percentiles.P90);
+            Assert.Equal(31, summary.Percentiles.P95);
+            Assert.Equal(31, summary.Percentiles.P100);
         }
     }
 }

--- a/BenchmarkDotNet/Columns/BaselineDiffColumn.cs
+++ b/BenchmarkDotNet/Columns/BaselineDiffColumn.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using BenchmarkDotNet.Extensions;
 using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Mathematics;
 using BenchmarkDotNet.Reports;
 using BenchmarkDotNet.Running;
 
@@ -16,15 +17,22 @@ namespace BenchmarkDotNet.Columns
 
         public static readonly IColumn Delta = new BaselineDiffColumn(DiffKind.Delta);
         public static readonly IColumn Scaled = new BaselineDiffColumn(DiffKind.Scaled);
+        public static readonly IColumn Scaled50 = new BaselineDiffColumn(DiffKind.Scaled, 50);
+        public static readonly IColumn Scaled85 = new BaselineDiffColumn(DiffKind.Scaled, 85);
+        public static readonly IColumn Scaled95 = new BaselineDiffColumn(DiffKind.Scaled, 95);
 
         public DiffKind Kind { get; set; }
+        public int? Percentile { get; set; }
 
-        private BaselineDiffColumn(DiffKind kind)
+        private BaselineDiffColumn(DiffKind kind, int? percentile = null)
         {
             Kind = kind;
+            Percentile = percentile;
         }
 
-        public string ColumnName => Kind.ToString();
+        public string ColumnName => Percentile == null ?
+            Kind.ToString() :
+            Kind.ToString() + "P" + Percentile?.ToString();
 
         public string GetValue(Summary summary, Benchmark benchmark)
         {
@@ -41,18 +49,34 @@ namespace BenchmarkDotNet.Columns
             if (invalidResults)
                 return "?";
 
-            var baselineMedian = summary[baselineBenchmark].ResultStatistics.Median;
-            var currentMedian = summary[benchmark].ResultStatistics.Median;
+            double baselineMetric;
+            double currentMetric;
+
+            var resultStatistics = summary[baselineBenchmark].ResultStatistics;
+            var statistics = summary[benchmark].ResultStatistics;
+            if (Percentile == null)
+            {
+                baselineMetric = resultStatistics.Median;
+                currentMetric = statistics.Median;
+            }
+            else
+            {
+                baselineMetric = resultStatistics.Percentiles.Percentile(Percentile.GetValueOrDefault());
+                currentMetric = statistics.Percentiles.Percentile(Percentile.GetValueOrDefault());
+            }
+
+            if (baselineMetric == 0)
+                return "?";
 
             switch (Kind)
             {
                 case DiffKind.Delta:
                     if (benchmark.Target.Baseline)
                         return "Baseline";
-                    var diff = (currentMedian - baselineMedian)/baselineMedian*100.0;
+                    var diff = (currentMetric - baselineMetric) / baselineMetric * 100.0;
                     return diff.ToStr("N1") + "%";
                 case DiffKind.Scaled:
-                    var scale = currentMedian/baselineMedian;
+                    var scale = currentMetric / baselineMetric;
                     return scale.ToStr("N2");
                 default:
                     return "?";

--- a/BenchmarkDotNet/Columns/StatisticColumn.cs
+++ b/BenchmarkDotNet/Columns/StatisticColumn.cs
@@ -21,6 +21,16 @@ namespace BenchmarkDotNet.Columns
         public static readonly IColumn Q3 = new StatisticColumn("Q3", s => s.Q3);
         public static readonly IColumn Max = new StatisticColumn("Max", s => s.Max);
 
+        public static readonly IColumn P0 = new StatisticColumn("P0", s => s.Percentiles.P0);
+        public static readonly IColumn P25 = new StatisticColumn("P25", s => s.Percentiles.P25);
+        public static readonly IColumn P50 = new StatisticColumn("P50", s => s.Percentiles.P50);
+        public static readonly IColumn P67 = new StatisticColumn("P67", s => s.Percentiles.P67);
+        public static readonly IColumn P80 = new StatisticColumn("P80", s => s.Percentiles.P80);
+        public static readonly IColumn P85 = new StatisticColumn("P85", s => s.Percentiles.P85);
+        public static readonly IColumn P90 = new StatisticColumn("P90", s => s.Percentiles.P90);
+        public static readonly IColumn P95 = new StatisticColumn("P95", s => s.Percentiles.P95);
+        public static readonly IColumn P100 = new StatisticColumn("P100", s => s.Percentiles.P100);
+
         public static IColumn CiLower(ConfidenceLevel level) => new StatisticColumn($"CI {level.ToPercent()}% Lower",
             s => new ConfidenceInterval(s.Mean, s.StandardError, level).Lower);
         public static IColumn CiUpper(ConfidenceLevel level) => new StatisticColumn($"CI {level.ToPercent()}% Upper",

--- a/BenchmarkDotNet/Mathematics/PercentileValues.cs
+++ b/BenchmarkDotNet/Mathematics/PercentileValues.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using BenchmarkDotNet.Extensions;
+using BenchmarkDotNet.Horology;
+using BenchmarkDotNet.Reports;
+
+namespace BenchmarkDotNet.Mathematics
+{
+    public class PercentileValues
+    {
+        /// <summary>
+        /// Calculates the Nth percentile from the set of values
+        /// </summary>
+        /// <remarks>
+        /// The implementation is expected to be consitent with the one from Excel.
+        /// It's a quite common to export bench output into .csv for further analysis 
+        /// And it's a good idea to have same results from all tools being used.
+        /// </remarks>
+        /// <param name="values">Sequence of the values to be calculated</param>
+        /// <param name="percentile">Value in range 0..100</param>
+        /// <returns>Percentile from the set of values</returns>
+        // BASEDON: http://stackoverflow.com/a/8137526
+        private static double Percentile(List<double> sortedValues, int percentile)
+        {
+            if (sortedValues == null)
+                throw new ArgumentNullException(nameof(sortedValues));
+            if (percentile < 0 || percentile > 100)
+            {
+                throw new ArgumentOutOfRangeException(
+                     nameof(percentile), percentile,
+                     "The percentile arg should be in range of 0 - 100.");
+            }
+
+            if (sortedValues.Count == 0)
+                return 0;
+
+            // DONTTOUCH: the following code was taken from http://stackoverflow.com/a/8137526 and it is proven
+            // to work in the same way the excel's counterpart does.
+            // So it's better to leave it as it is unless you do not want to reimplement it from scratch:)
+            double realIndex = percentile / 100.0 * (sortedValues.Count - 1);
+            int index = (int)realIndex;
+            double frac = realIndex - index;
+            if (index + 1 < sortedValues.Count)
+                return sortedValues[index] * (1 - frac) + sortedValues[index + 1] * frac;
+            else
+                return sortedValues[index];
+        }
+
+        public double Percentile(int percentile) => Percentile(SortedValues, percentile);
+
+        private List<double> SortedValues { get; }
+
+        public double P0 { get; }
+        public double P25 { get; }
+        public double P50 { get; }
+        public double P67 { get; }
+        public double P80 { get; }
+        public double P85 { get; }
+        public double P90 { get; }
+        public double P95 { get; }
+        public double P100 { get; }
+
+        internal PercentileValues(List<double> sortedValues)
+        {
+            SortedValues = sortedValues;
+
+            // TODO: Collect all in one call?
+            P0 = Percentile(0);
+            P25 = Percentile(25);
+            P50 = Percentile(50);
+            P67 = Percentile(67);
+            P80 = Percentile(80);
+            P85 = Percentile(85);
+            P90 = Percentile(90);
+            P95 = Percentile(95);
+            P100 = Percentile(100);
+        }
+
+        public string ToStr(bool showLevel = true) => $"[.95: {P95.ToStr()}] (0: {P0.ToStr()}]; .5: {P50.ToStr()}; 1: {P100.ToStr()})";
+        public string ToTimeStr(TimeUnit unit = null, bool showLevel = true) => $"[.95: {P95.ToTimeStr(unit)}] (0: {P0.ToTimeStr(unit)}]; .5: {P50.ToTimeStr(unit)}; 1: {P100.ToTimeStr(unit)})";
+    }
+}

--- a/BenchmarkDotNet/Mathematics/Statistics.cs
+++ b/BenchmarkDotNet/Mathematics/Statistics.cs
@@ -22,6 +22,7 @@ namespace BenchmarkDotNet.Mathematics
         public double StandardError { get; }
         public double StandardDeviation { get; }
         public ConfidenceInterval ConfidenceInterval { get; }
+        public PercentileValues Percentiles { get; }
 
         public Statistics(params double[] values) :
             this(values.ToList())
@@ -66,6 +67,7 @@ namespace BenchmarkDotNet.Mathematics
             StandardDeviation = N == 1 ? 0 : Math.Sqrt(list.Sum(d => Math.Pow(d - Mean, 2)) / (N - 1));
             StandardError = StandardDeviation / Math.Sqrt(N);
             ConfidenceInterval = new ConfidenceInterval(Mean, StandardError);
+            Percentiles = new PercentileValues(list);
         }
 
         public bool IsOutlier(double value) => value < LowerFence || value > UpperFence;

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 * Standard benchmarking routine: generating an isolated project per each benchmark method; auto-selection of iteration amount; warmup; overhead evaluation; statistics calculation; and so on.
 * Easy way to compare different environments (`x86` vs `x64`, `LegacyJit` vs `RyuJit`, and so on; see: [Jobs](#jobs))
 * Reports: markdown (default, github, stackoverflow), csv, html, plain text; png plots.
-* Advanced features: [Baseline](#baseline), [Params](#params)
+* Advanced features: [Baseline](#baseline), [Params](#params), [Percentiles](#percentiles)
 * Powerful diagnostics based on ETW events (currently, works only from source)
 * Supported runtimes: Full .NET Framework, Mono, Dnx451, DnxCore50 (in prerelease version)
 * Supported languages: C#, F# (also on [.NET Core](https://github.com/PerfDotNet/BenchmarkDotNet/issues/135)) and Visual Basic
@@ -280,7 +280,17 @@ class StatisticColumn
     IColumn Median;
     IColumn Q3;
     IColumn Max;
-    IColumn[] AllStatistics = { Time, Error, StdDev, OperationPerSecond, Min, Q1, Median, Q3, Max };}
+    
+    IColumn P0;
+    IColumn P25;
+    IColumn P50;
+    IColumn P80;
+    IColumn P85;
+    IColumn P90;
+    IColumn P95;
+    IColumn P100;
+
+    IColumn[] AllStatistics = { Mean, StdError, StdDev, OperationsPerSecond, Min, Q1, Median, Q3, Max };
 }
 // Specify a "place" of each benchmark. Place 1 means a group of the fastest benchmarks, place 2 means the second group, and so on. There are several styles:
 class Place
@@ -535,6 +545,61 @@ Type=Sleeps  Mode=Throughput
  Time100 | 100.2640 ms | 0.1238 ms |   1.00
  Time150 | 150.2093 ms | 0.1034 ms |   1.50
   Time50 |  50.2509 ms | 0.1153 ms |   0.50
+
+
+### Percentiles
+
+The percentile represents a higer boundary for specified percengage of a measurements.
+For example, 95th percentile = 500ms means that 95% of all samples are not slower than 500ms.
+This metric is not very useful in microbenchmarks, as the values from consequent runs have a very narrow distribution.
+Hovewer, real-world scenarios often have so-called long tail distribution (due to IO delays, locks, memory access latency and so on), so the average execution time cannot be trusted.
+
+The percentiles allow to include the tail of distribution into the comparison. Hovewer, it requires some preparations steps.
+
+At first, you should have enough runs to count percentiles from. The `TargetCount` in the config should be set to 10-20 runs at least.  
+Second, the count of iterations for each run should not be very high, or the peak timings will be averaged.  
+ The `IterationTime = 25` works fine for most cases; for long-running benchmarks the `Mode = Mode.SingleRun` will be the best choice. Hovewer, feel free to experiment with the config values.
+
+Third, if you want to be sure that measurements are repeatable, set the `LanuchCount` to 3 or higher.
+
+And the last, don't forget to include the columns into the config. They are not included by default (as said above, these are not too useful for most of the benchmarks).
+There're predefined `StatisticColumn.P0`..`StatisticColumn.P100` for absolute timing percentiles and `BaselineDiffColumn.Scaled50`..`BaselineDiffColumn.Scaled95` for relative percentiles.
+
+**The sample:**
+
+Run the IntroPercentiles sample. 
+It contains three benchmark methods.
+* First delays for 20 ms constantly.
+* The second has random delays for 10..30 ms.
+* And the third delays for 10ms 85 times of 100 and delays for 40ms 15 times of 100.
+
+Here's the output from the benchmark (some columns removed for brevity):
+
+         Method |     Median |     StdDev | Scaled |         P0 |        P50 |        P80 |        P85 |        P95 |       P100 | ScaledP50 | ScaledP85 | ScaledP95
+--------------- |----------- |----------- |------- |----------- |----------- |----------- |----------- |----------- |----------- |---------- |---------- |----------
+ ConstantDelays | 20.3813 ms |  0.2051 ms |   1.00 | 20.0272 ms | 20.3813 ms | 20.4895 ms | 20.4954 ms | 20.5869 ms | 21.1471 ms |      1.00 |      1.00 |      1.00
+   RandomDelays | 19.8055 ms |  5.7556 ms |   0.97 | 10.0793 ms | 19.8055 ms | 25.4173 ms | 26.5187 ms | 29.0313 ms | 29.4550 ms |      0.97 |      1.29 |      1.41
+     RareDelays | 10.3385 ms | 11.4828 ms |   0.51 | 10.0157 ms | 10.3385 ms | 10.5211 ms | 40.0560 ms | 40.3992 ms | 40.4674 ms |      0.51 |      1.95 |      1.96
+
+Note that the 'Scaled' column kinda lies to you. 
+The "almost same" RandomDelays method is actually not so performant and the seems-to-be-fastest RareDelays method is 2 times slower 15 times of 100.
+
+Also, it's very easy to screw the results with incorrect setup. For example, the same code being run with
+```cs
+                new Job
+                {
+                    TargetCount = 5,
+                    IterationTime = 500
+                }
+```
+completely hides the peak values:
+
+         Method |     Median |    StdDev | Scaled |         P0 |        P50 |        P80 |        P85 |        P95 |       P100 | ScaledP50 | ScaledP85 | ScaledP95
+--------------- |----------- |---------- |------- |----------- |----------- |----------- |----------- |----------- |----------- |---------- |---------- |----------
+ ConstantDelays | 20.2692 ms | 0.0308 ms |   1.00 | 20.1986 ms | 20.2692 ms | 20.2843 ms | 20.2968 ms | 20.3097 ms | 20.3122 ms |      1.00 |      1.00 |      1.00
+   RandomDelays | 18.9965 ms | 0.8601 ms |   0.94 | 18.1339 ms | 18.9965 ms | 19.8126 ms | 19.8278 ms | 20.4485 ms | 20.9466 ms |      0.94 |      0.98 |      1.01
+     RareDelays | 14.0912 ms | 2.8619 ms |   0.70 | 10.2606 ms | 14.0912 ms | 15.7653 ms | 17.3862 ms | 18.6728 ms | 18.6940 ms |      0.70 |      0.86 |      0.92
+
 
 ## Rules of benchmarking
 


### PR DESCRIPTION
Redo #138.

The text from the original PR:

As I wrote [here](https://github.com/PerfDotNet/BenchmarkDotNet/issues/126#issuecomment-200302063) I begin to do small PR to make it easier to use BenchmarkDotNet as an competition tests runner.

This PR adds Nth percentile and Nth percenile scaled columns. These should be used to rank and to compare competitors if the timings are varying from run to run.

More info on these: 
http://www.goland.org/average_percentile_services/
http://apmblog.dynatrace.com/2012/11/14/why-averages-suck-and-percentiles-are-great/

P.S. I'm not sure that proposed API design is good enough so it's definitely subject to discuss:)