### PR TITLE
Support export to asciidoc

### DIFF
--- a/BenchmarkDotNet/Configs/ConfigParser.cs
+++ b/BenchmarkDotNet/Configs/ConfigParser.cs
@@ -102,6 +102,7 @@ namespace BenchmarkDotNet.Configs
                 { "plain", new[] { PlainExporter.Default } },
                 { "rplot", new[] { RPlotExporter.Default } },
                 { "json", new[] { JsonExporter.Default } },
+                { "asciidoc", new[] { AsciiDocExporter.Default } },
             };
         private static Lazy<IExporter[]> allExporters = new Lazy<IExporter[]>(() => availableExporters.SelectMany(e => e.Value).ToArray());
 

--- a/BenchmarkDotNet/Exporters/AsciiDocExporter.cs
+++ b/BenchmarkDotNet/Exporters/AsciiDocExporter.cs
@@ -1,0 +1,69 @@
+﻿using System.Linq;
+using BenchmarkDotNet.Helpers;
+using BenchmarkDotNet.Loggers;
+using BenchmarkDotNet.Reports;
+
+namespace BenchmarkDotNet.Exporters
+{
+    public class AsciiDocExporter : ExporterBase
+    {
+        protected override string FileExtension => "asciidoc";
+
+        public static readonly IExporter Default = new AsciiDocExporter();
+
+        private AsciiDocExporter()
+        {
+        }
+
+        public override void ExportToLog(Summary summary, ILogger logger)
+        {
+            logger.WriteLine("....");
+            foreach (var infoLine in EnvironmentInfo.GetCurrent().ToFormattedString("Host", true))
+            {
+                logger.WriteLineInfo(infoLine);
+            }
+            logger.WriteLine();
+
+            PrintTable(summary.Table, logger);
+
+            var benchmarksWithTroubles = summary.Reports
+                .Where(r => !r.GetResultRuns().Any())
+                .Select(r => r.Benchmark)
+                .ToList();
+
+            if (benchmarksWithTroubles.Count > 0)
+            {
+                logger.WriteLine();
+                logger.WriteLine("[WARNING]");
+                logger.WriteLineError(".Benchmarks with issues");
+                logger.WriteLine("====");
+                foreach (var benchmarkWithTroubles in benchmarksWithTroubles)
+                    logger.WriteLineError("* " + benchmarkWithTroubles.ShortInfo);
+                logger.WriteLine("====");
+            }
+        }
+
+        private static void PrintTable(SummaryTable table, ILogger logger)
+        {
+            if (table.FullContent.Length == 0)
+            {
+                logger.WriteLine("[WARNING]");
+                logger.WriteLine("====");
+                logger.WriteLineError("There are no benchmarks found ");
+                logger.WriteLine("====");
+                logger.WriteLine();
+                return;
+            }
+
+            table.PrintCommonColumns(logger);
+            logger.WriteLine("....");
+
+            logger.WriteLine("[options=\"header\"]");
+            logger.WriteLine("|===");
+            table.PrintLine(table.FullHeader, logger, "|", string.Empty);
+            foreach (var line in table.FullContent)
+                table.PrintLine(line, logger, "|", string.Empty);
+            logger.WriteLine("|===");
+        }
+    }
+}


### PR DESCRIPTION
Support for exporting to [asciidoc format](http://asciidoc.org/userguide.html).

See https://github.com/PerfDotNet/BenchmarkDotNet/pull/165 for original PR.

I'm unable to run tests to check the output at the moment; I've raised issue https://github.com/PerfDotNet/BenchmarkDotNet/issues/168. I've [implemented the exporter here with the same impl](https://github.com/elastic/elasticsearch-net/blob/6e301c6c1350f9c81fb8e310c51dbb988939b0c2/src/Tests/Framework/Benchmarks/AsciiDocExporter.cs)and checked the output.