### PR TITLE
Prerequisites for machines running VS2015+ - Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 
 ## Content
 
+* [Prerequisites](#prerequisites)
 * [Getting started](#getting-started)
 * [Configs](#configs)
 * [Advanced features](#advanced-features)
@@ -25,6 +26,11 @@
 * [How it works?](#how-it-works)
 * [FAQ](#faq)
 * [Team](#team)
+
+
+## Prerequisites
+
+If you are using Visual Studio 2015 and you do not have Visual Studio 2013 installed, you'll need the [Microsoft Build Tools 2013](https://www.microsoft.com/en-us/download/details.aspx?id=40760) installed on your machine.
 
 ## Getting started
 


### PR DESCRIPTION
Add a note about needing MSBuild12/Microsoft Build Tools 2013 installed on machines that are only running 2015+

I posted in Gitter about this issue a little while ago but forgot to test this before moving on to other tasks - https://www.microsoft.com/en-au/download/details.aspx?id=40760 allows BenchmarkDotNet to run correctly. The wording of this and creating a whole new section is a little clunky but I thought I better get the PR in before I completely forgot about it