### PR TITLE
Use same configured counts for IdleWarmup/Target as Main

### DIFF
--- a/BenchmarkDotNet/Running/MethodInvoker.cs
+++ b/BenchmarkDotNet/Running/MethodInvoker.cs
@@ -94,8 +94,8 @@ namespace BenchmarkDotNet.Running
             if (job.Mode == Mode.Throughput)
             {
                 invokeCount = RunPilot(multiInvoke, job.IterationTime);
-                RunWarmup(multiInvoke, invokeCount, IterationMode.IdleWarmup, Count.Auto);
-                idle = RunTarget(multiInvoke, invokeCount, IterationMode.IdleTarget, Count.Auto);
+                RunWarmup(multiInvoke, invokeCount, IterationMode.IdleWarmup, job.WarmupCount);
+                idle = RunTarget(multiInvoke, invokeCount, IterationMode.IdleTarget, job.TargetCount);
             }
 
             RunWarmup(multiInvoke, invokeCount, IterationMode.MainWarmup, job.WarmupCount);


### PR DESCRIPTION
The values should match the config.
Alternatively, it should be exposed for configuration.