### PR TITLE
Added appveyor ci build fix #77

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ nuget.exe
 **/project.lock.json
 testsOutput/*
 .vs/restore.dg
+BDN.Auto

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,77 @@
+#---------------------------------#
+#      general configuration      #
+#---------------------------------#
+
+# version format
+version: 0.9.7.{build}
+
+# branches to build
+branches:
+  # blacklist
+  except:
+    - gh-pages
+
+# Do not build on tags (GitHub only)
+skip_tags: true
+
+#---------------------------------#
+#    environment configuration    #
+#---------------------------------#
+
+# scripts that are called at very beginning, before repo cloning
+init:
+  - git config --global core.autocrlf input
+
+# scripts that run after cloning repository
+install:
+  # remove this when nuget 3.5 will be available on appveyor
+  - ps: Start-FileDownload "https://dist.nuget.org/win-x86-commandline/v3.5.0-beta/NuGet.exe"
+
+# enable patching of AssemblyInfo.* files
+assembly_info:
+  patch: true
+  file: AssemblyInfo.*
+  assembly_version: "{version}"
+  assembly_file_version: "{version}"
+  assembly_informational_version: "{version}"
+
+#---------------------------------#
+#       build configuration       #
+#---------------------------------#
+
+# build platform, i.e. x86, x64, Any CPU. This setting is optional.
+platform: Any CPU
+
+# build Configuration, i.e. Debug, Release, etc.
+configuration: Release
+
+os: Visual Studio 2015
+
+before_build:
+  - ps: .\build\version.ps1
+  - .\nuget.exe restore
+  - dotnet --info
+
+build:
+  parallel: true                  # enable MSBuild parallel builds
+  project: BenchmarkDotNet.sln    # path to Visual Studio solution or project
+
+after_build:
+  - dotnet pack .\BenchmarkDotNet\project.json --configuration Release
+  
+#---------------------------------#
+#       tests configuration       #
+#---------------------------------#
+before_test:
+  - dotnet test .\BenchmarkDotNet.Tests\project.json --configuration Release
+  - dotnet test .\BenchmarkDotNet.IntegrationTests\project.json --configuration Release
+
+test:
+  assemblies:
+    - BenchmarkDotNet.Tests\bin\$(configuration)\net451\win7-x64\BenchmarkDotNet.Tests.dll
+    - BenchmarkDotNet.IntegrationTests\bin\$(configuration)\net451\win7-x64\BenchmarkDotNet.IntegrationTests.dll
+    - BenchmarkDotNet.IntegrationTests.Classic\bin\$(configuration)\BenchmarkDotNet.IntegrationTests.Classic.exe
+
+artifacts:
+  - path: '**\BenchmarkDotNet.*.nupkg' # find all NuGet packages recursively
+

--- a/build/version.ps1
+++ b/build/version.ps1
@@ -1,0 +1,46 @@
+param(
+    [string]
+    $Version = $env:APPVEYOR_BUILD_VERSION
+)
+
+$projects = Get-ChildItem -Path $Path -Directory |
+                    foreach { "$($_.Fullname)\project.json" } |
+                    Where-Object { Test-Path $_ }
+
+function Set-DotnetProjectVersion
+{
+    param(
+        $project,
+        $version
+    )
+
+    $changed = $false
+    $json = Get-Content -Raw -Path $project | ConvertFrom-Json
+    if($json.version)
+    {
+        Write-Host "Setting version $version on project $project"
+        $json.version = $version
+        $changed = $true
+    }
+    
+    if($json.dependencies.BenchmarkDotNet.version)
+    {
+        $json.dependencies.BenchmarkDotNet.version = $version
+        $changed = $true
+    }
+    
+    if($changed)
+    {
+        $json | ConvertTo-Json -depth 999 | Out-File $project
+    }
+}
+
+if(-not ([string]::IsNullOrEmpty($Version)))
+{
+    Write-Host "Building version $Version"
+
+    foreach($project in $projects)
+    {
+        Set-DotnetProjectVersion $project $Version
+    }
+}


### PR DESCRIPTION
Added support for appveyor.
The build currently fails due to some tests failing, otherwise it should work properly.
This fix issue #77 
An example build can be found here:
https://ci.appveyor.com/project/gigi81/benchmarkdotnet

You will need to create an account on appveyor after the merge (and add a badge on the readme?).