### PR TITLE
Fixed tests not using OutputLogger

### DIFF
--- a/BenchmarkDotNet.IntegrationTests/MemoryDiagnoserTests.cs
+++ b/BenchmarkDotNet.IntegrationTests/MemoryDiagnoserTests.cs
@@ -5,6 +5,7 @@ using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Running;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace BenchmarkDotNet.IntegrationTests
 {
@@ -46,6 +47,13 @@ namespace BenchmarkDotNet.IntegrationTests
     // this class is not compiled for CORE because it is using Diagnosers that currently do not support Core
     public class MemoryDiagnoserTests 
     {
+        private readonly ITestOutputHelper _output;
+
+        public MemoryDiagnoserTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
         [Fact]
         public void Test()
         {
@@ -59,7 +67,8 @@ namespace BenchmarkDotNet.IntegrationTests
                         .With(Job.Dry.With(Runtime.Core).With(Jit.Host).With(Mode.Throughput).WithWarmupCount(1).WithTargetCount(1))
                         .With(DefaultConfig.Instance.GetLoggers().ToArray())
                         .With(DefaultConfig.Instance.GetColumns().ToArray())
-                        .With(memoryDiagnoser));
+                        .With(memoryDiagnoser)
+                        .With(new OutputLogger(_output)));
 
             var gcCollectionColumns = memoryDiagnoser.GetColumns.OfType<Diagnostics.Windows.MemoryDiagnoser.GCCollectionColumn>().ToArray();
             var listStructEnumeratorBenchmarks = benchmarks.Where(benchmark => benchmark.ShortInfo.Contains("ListStructEnumerator"));

--- a/BenchmarkDotNet.IntegrationTests/MemoryDiagnoserTests.cs
+++ b/BenchmarkDotNet.IntegrationTests/MemoryDiagnoserTests.cs
@@ -47,11 +47,11 @@ namespace BenchmarkDotNet.IntegrationTests
     // this class is not compiled for CORE because it is using Diagnosers that currently do not support Core
     public class MemoryDiagnoserTests 
     {
-        private readonly ITestOutputHelper _output;
+        private readonly ITestOutputHelper output;
 
-        public MemoryDiagnoserTests(ITestOutputHelper output)
+        public MemoryDiagnoserTests(ITestOutputHelper outputHelper)
         {
-            _output = output;
+            output = outputHelper;
         }
 
         [Fact]
@@ -68,7 +68,7 @@ namespace BenchmarkDotNet.IntegrationTests
                         .With(DefaultConfig.Instance.GetLoggers().ToArray())
                         .With(DefaultConfig.Instance.GetColumns().ToArray())
                         .With(memoryDiagnoser)
-                        .With(new OutputLogger(_output)));
+                        .With(new OutputLogger(output)));
 
             var gcCollectionColumns = memoryDiagnoser.GetColumns.OfType<Diagnostics.Windows.MemoryDiagnoser.GCCollectionColumn>().ToArray();
             var listStructEnumeratorBenchmarks = benchmarks.Where(benchmark => benchmark.ShortInfo.Contains("ListStructEnumerator"));

--- a/BenchmarkDotNet.IntegrationTests/MultipleRuntimesTest.cs
+++ b/BenchmarkDotNet.IntegrationTests/MultipleRuntimesTest.cs
@@ -6,11 +6,19 @@ using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Toolchains;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace BenchmarkDotNet.IntegrationTests
 {
     public class MultipleRuntimesTest
     {
+        private readonly ITestOutputHelper _output;
+
+        public MultipleRuntimesTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
         [Fact]
         public void SingleBenchmarkCanBeExecutedForMultpleRuntimes()
         {
@@ -19,7 +27,8 @@ namespace BenchmarkDotNet.IntegrationTests
                     ManualConfig.CreateEmpty()
                                 .With(Job.Dry.With(Runtime.Dnx))
                                 .With(Job.Dry.With(Runtime.Core))
-                                .With(Job.Dry.With(Runtime.Clr).With(Framework.V46)));
+                                .With(Job.Dry.With(Runtime.Clr).With(Framework.V46))
+                                .With(new OutputLogger(_output)));
 
             Assert.True(summary.Reports
                 .All(report => report.ExecuteResults

--- a/BenchmarkDotNet.IntegrationTests/MultipleRuntimesTest.cs
+++ b/BenchmarkDotNet.IntegrationTests/MultipleRuntimesTest.cs
@@ -12,11 +12,11 @@ namespace BenchmarkDotNet.IntegrationTests
 {
     public class MultipleRuntimesTest
     {
-        private readonly ITestOutputHelper _output;
+        private readonly ITestOutputHelper output;
 
-        public MultipleRuntimesTest(ITestOutputHelper output)
+        public MultipleRuntimesTest(ITestOutputHelper outputHelper)
         {
-            _output = output;
+            output = outputHelper;
         }
 
         [Fact]
@@ -28,7 +28,7 @@ namespace BenchmarkDotNet.IntegrationTests
                                 .With(Job.Dry.With(Runtime.Dnx))
                                 .With(Job.Dry.With(Runtime.Core))
                                 .With(Job.Dry.With(Runtime.Clr).With(Framework.V46))
-                                .With(new OutputLogger(_output)));
+                                .With(new OutputLogger(output)));
 
             Assert.True(summary.Reports
                 .All(report => report.ExecuteResults

--- a/BenchmarkDotNet.IntegrationTests/OutputLogger.cs
+++ b/BenchmarkDotNet.IntegrationTests/OutputLogger.cs
@@ -10,6 +10,9 @@ namespace BenchmarkDotNet.IntegrationTests
 
         public OutputLogger(ITestOutputHelper testOutputHelper)
         {
+            if (testOutputHelper == null)
+                throw new ArgumentNullException(nameof(testOutputHelper));
+
             this.testOutputHelper = testOutputHelper;
         }
 

--- a/BenchmarkDotNet.IntegrationTests/PerformanceUnitTest.cs
+++ b/BenchmarkDotNet.IntegrationTests/PerformanceUnitTest.cs
@@ -14,17 +14,17 @@ namespace BenchmarkDotNet.IntegrationTests
 {
     public class PerformanceUnitTestRunner
     {
-        private readonly ITestOutputHelper _output;
+        private readonly ITestOutputHelper output;
 
-        public PerformanceUnitTestRunner(ITestOutputHelper output)
+        public PerformanceUnitTestRunner(ITestOutputHelper outputHelper)
         {
-            _output = output;
+            output = outputHelper;
         }
 
         [Fact]
         public void Test()
         {
-            var logger = new OutputLogger(_output);
+            var logger = new OutputLogger(output);
             var config = DefaultConfig.Instance.With(logger);
             var summary = BenchmarkRunner.Run<PerformanceUnitTest>(config);
 

--- a/BenchmarkDotNet.IntegrationTests/PerformanceUnitTest.cs
+++ b/BenchmarkDotNet.IntegrationTests/PerformanceUnitTest.cs
@@ -8,16 +8,23 @@ using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Reports;
 using BenchmarkDotNet.Running;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace BenchmarkDotNet.IntegrationTests
 {
-    [Config(typeof(SingleRunFastConfig))]
-    public class PerformanceUnitTest
+    public class PerformanceUnitTestRunner
     {
+        private readonly ITestOutputHelper _output;
+
+        public PerformanceUnitTestRunner(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
         [Fact]
         public void Test()
         {
-            var logger = new AccumulationLogger();
+            var logger = new OutputLogger(_output);
             var config = DefaultConfig.Instance.With(logger);
             var summary = BenchmarkRunner.Run<PerformanceUnitTest>(config);
 
@@ -44,7 +51,11 @@ namespace BenchmarkDotNet.IntegrationTests
             foreach (var fastRun in fastBenchmarkReport.GetResultRuns())
                 Assert.InRange(fastRun.GetAverageNanoseconds() / 1000.0 / 1000.0, low: 14, high: 17);
         }
+    }
 
+    [Config(typeof(SingleRunFastConfig))]
+    public class PerformanceUnitTest
+    {
         [Benchmark]
         public void FastBenchmark()
         {

--- a/BenchmarkDotNet.IntegrationTests/ProcessorArchitectureTest.cs
+++ b/BenchmarkDotNet.IntegrationTests/ProcessorArchitectureTest.cs
@@ -25,11 +25,11 @@ namespace BenchmarkDotNet.IntegrationTests
         const string HostPlatformOkCaption = "// HostPlatformOkCaption";
         const string BenchmarkNotFound = "// There are no benchmarks found";
 
-        private readonly ITestOutputHelper _output;
+        private readonly ITestOutputHelper output;
 
-        public ProcessorArchitectureTest(ITestOutputHelper output)
+        public ProcessorArchitectureTest(ITestOutputHelper outputHelper)
         {
-            _output = output;
+            output = outputHelper;
         }
 
         [Fact]
@@ -45,7 +45,7 @@ namespace BenchmarkDotNet.IntegrationTests
 
         private void Verify(Platform platform, Type benchmark, string failureText)
         {
-            var logger = new OutputLogger(_output);
+            var logger = new OutputLogger(output);
             // make sure we get an output in the TestRunner log
             var config = new PlatformConfig(platform)
                                 .With(logger)

--- a/BenchmarkDotNet.IntegrationTests/ProcessorArchitectureTest.cs
+++ b/BenchmarkDotNet.IntegrationTests/ProcessorArchitectureTest.cs
@@ -5,10 +5,10 @@ using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Jobs;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace BenchmarkDotNet.IntegrationTests
 {
-    [Config(typeof(PlatformConfig))]
     public class ProcessorArchitectureTest
     {
         private class PlatformConfig : ManualConfig
@@ -25,6 +25,13 @@ namespace BenchmarkDotNet.IntegrationTests
         const string HostPlatformOkCaption = "// HostPlatformOkCaption";
         const string BenchmarkNotFound = "// There are no benchmarks found";
 
+        private readonly ITestOutputHelper _output;
+
+        public ProcessorArchitectureTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
         [Fact]
         public void SpecifiedProccesorArchitectureMustBeRespected()
         {
@@ -38,9 +45,11 @@ namespace BenchmarkDotNet.IntegrationTests
 
         private void Verify(Platform platform, Type benchmark, string failureText)
         {
-            var logger = new AccumulationLogger();
+            var logger = new OutputLogger(_output);
             // make sure we get an output in the TestRunner log
-            var config = new PlatformConfig(platform).With(logger).With(ConsoleLogger.Default);
+            var config = new PlatformConfig(platform)
+                                .With(logger)
+                                .With(ConsoleLogger.Default);
 
             BenchmarkTestExecutor.CanExecute(benchmark, config);
             var testLog = logger.GetLog();

--- a/BenchmarkDotNet.IntegrationTests/ValidatorsTest.cs
+++ b/BenchmarkDotNet.IntegrationTests/ValidatorsTest.cs
@@ -24,11 +24,11 @@ namespace BenchmarkDotNet.IntegrationTests
                 PlainExporter.Default,
             };
 
-        private readonly ITestOutputHelper _output;
+        private readonly ITestOutputHelper output;
 
-        public ValidatorsTest(ITestOutputHelper output)
+        public ValidatorsTest(ITestOutputHelper outputHelper)
         {
-            _output = output;
+            output = outputHelper;
         }
 
         [Fact]
@@ -40,7 +40,7 @@ namespace BenchmarkDotNet.IntegrationTests
                         .CreateEmpty()
                         .With(new FailingValidator())
                         .With(ConsoleLogger.Default) // so we get an output in the TestRunner log
-                        .With(new OutputLogger(_output))
+                        .With(new OutputLogger(output))
                         .With(AllKnownExportersThatSupportExportToLog));
         }
 
@@ -52,7 +52,7 @@ namespace BenchmarkDotNet.IntegrationTests
                     ManualConfig
                         .CreateEmpty()
                         .With(ConsoleLogger.Default) // so we get an output in the TestRunner log
-                        .With(new OutputLogger(_output))
+                        .With(new OutputLogger(output))
                         .With(new FailingValidator()));
 
             foreach (var exporter in AllKnownExportersThatSupportExportToLog)

--- a/BenchmarkDotNet.IntegrationTests/ValidatorsTest.cs
+++ b/BenchmarkDotNet.IntegrationTests/ValidatorsTest.cs
@@ -6,6 +6,7 @@ using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Exporters;
 using BenchmarkDotNet.Loggers;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace BenchmarkDotNet.IntegrationTests
 {
@@ -23,15 +24,23 @@ namespace BenchmarkDotNet.IntegrationTests
                 PlainExporter.Default,
             };
 
+        private readonly ITestOutputHelper _output;
+
+        public ValidatorsTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
         [Fact]
         public void BenchmarkRunnerShouldNotFailOnCriticalValidationErrors()
         {
             BenchmarkRunner
-                .Run<ValidatorsTest>(
+                .Run<Nothing>(
                     ManualConfig
                         .CreateEmpty()
                         .With(new FailingValidator())
                         .With(ConsoleLogger.Default) // so we get an output in the TestRunner log
+                        .With(new OutputLogger(_output))
                         .With(AllKnownExportersThatSupportExportToLog));
         }
 
@@ -39,10 +48,11 @@ namespace BenchmarkDotNet.IntegrationTests
         public void LoggersShouldNotFailOnCriticalValidationErrors()
         {
             var summary = BenchmarkRunner
-                .Run<ValidatorsTest>(
+                .Run<Nothing>(
                     ManualConfig
                         .CreateEmpty()
                         .With(ConsoleLogger.Default) // so we get an output in the TestRunner log
+                        .With(new OutputLogger(_output))
                         .With(new FailingValidator()));
 
             foreach (var exporter in AllKnownExportersThatSupportExportToLog)
@@ -61,7 +71,10 @@ namespace BenchmarkDotNet.IntegrationTests
             }
         }
 
-        [Benchmark]
-        public void Nothing() { }
+        public class Nothing
+        {
+            [Benchmark]
+            public void DoNothing() { }
+        }
     }
 }


### PR DESCRIPTION
Wired up OutputLogger to tests that were not using it so that output can
be seen in AppVeyor under the tests tab