### PR TITLE
Added Api docs generation directives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ _ReSharper*/
 packages/
 nuget.exe
 docs/guidehtml
+docs/apihtml
 
 .idea/
 *.iml

--- a/docs/api/BenchmarkDotNet.shfbproj
+++ b/docs/api/BenchmarkDotNet.shfbproj
@@ -56,17 +56,23 @@
         <component id="API Token Resolution">{@TokenFiles}
 <replace elements="/*//token" item="string(.)" /></component>
       </ComponentConfig>
-<ComponentConfig id="Code Block Component" enabled="True" xmlns=""><component id="Code Block Component">
-  <basePath value="{@HtmlEncProjectFolder}" />
-  <outputPaths>{@HelpFormatOutputPaths}</outputPaths>
-  <allowMissingSource value="false" />
-  <removeRegionMarkers value="false" />
-  <colorizer syntaxFile="{@SHFBFolder}PresentationStyles\Colorizer\highlight.xml" styleFile="{@SHFBFolder}PresentationStyles\Colorizer\highlight.xsl" stylesheet="{@SHFBFolder}PresentationStyles\Colorizer\highlight.css" scriptFile="{@SHFBFolder}PresentationStyles\Colorizer\highlight.js" disabled="{@DisableCodeBlockComponent}" language="cs" tabSize="0" numberLines="false" outlining="false" keepSeeTags="false" defaultTitle="true" />
-</component></ComponentConfig></ComponentConfigurations>
+      <ComponentConfig id="Code Block Component" enabled="True" xmlns="">
+        <component id="Code Block Component">
+          <basePath value="{@HtmlEncProjectFolder}" />
+          <outputPaths>{@HelpFormatOutputPaths}</outputPaths>
+          <allowMissingSource value="false" />
+          <removeRegionMarkers value="false" />
+          <colorizer syntaxFile="{@SHFBFolder}PresentationStyles\Colorizer\highlight.xml" styleFile="{@SHFBFolder}PresentationStyles\Colorizer\highlight.xsl" stylesheet="{@SHFBFolder}PresentationStyles\Colorizer\highlight.css" scriptFile="{@SHFBFolder}PresentationStyles\Colorizer\highlight.js" disabled="{@DisableCodeBlockComponent}" language="cs" tabSize="0" numberLines="false" outlining="false" keepSeeTags="false" defaultTitle="true" />
+        </component>
+      </ComponentConfig>
+    </ComponentConfigurations>
     <DocumentationSources>
-      <DocumentationSource sourceFile="..\..\src\BenchmarkDotNet\bin\Debug\net45\BenchmarkDotNet.Core.dll" />
-<DocumentationSource sourceFile="..\..\src\BenchmarkDotNet\bin\Debug\net45\BenchmarkDotNet.dll" />
-<DocumentationSource sourceFile="..\..\src\BenchmarkDotNet.Diagnostics.Windows\bin\Debug\net45\BenchmarkDotNet.Diagnostics.Windows.dll" /></DocumentationSources>
+      <DocumentationSource sourceFile="..\..\src\BenchmarkDotNet\bin\Release\net45\BenchmarkDotNet.Core.dll" />
+<DocumentationSource sourceFile="..\..\src\BenchmarkDotNet\bin\Release\net45\BenchmarkDotNet.dll" />
+<DocumentationSource sourceFile="..\..\src\BenchmarkDotNet.Diagnostics.Windows\bin\Release\net45\BenchmarkDotNet.Diagnostics.Windows.dll" />
+<DocumentationSource sourceFile="..\..\src\BenchmarkDotNet\bin\Release\net45\BenchmarkDotNet.Core.xml" />
+<DocumentationSource sourceFile="..\..\src\BenchmarkDotNet.Diagnostics.Windows\bin\Release\net45\BenchmarkDotNet.Diagnostics.Windows.xml" />
+<DocumentationSource sourceFile="..\..\src\BenchmarkDotNet\bin\Release\net45\BenchmarkDotNet.xml" /></DocumentationSources>
   </PropertyGroup>
   <!-- There are no properties for these groups.  AnyCPU needs to appear in order for Visual Studio to perform
 			 the build.  The others are optional common platform types that may appear. -->

--- a/docs/api/BenchmarkDotNet.shfbproj
+++ b/docs/api/BenchmarkDotNet.shfbproj
@@ -1,0 +1,100 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- The configuration and platform will be used to determine which assemblies to include from solution and
+				 project documentation sources -->
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{55a091dd-fbd4-4ef5-bbef-2c9c7ec5e67a}</ProjectGuid>
+    <SHFBSchemaVersion>2015.6.5.0</SHFBSchemaVersion>
+    <!-- AssemblyName, Name, and RootNamespace are not used by SHFB but Visual Studio adds them anyway -->
+    <AssemblyName>Documentation</AssemblyName>
+    <RootNamespace>Documentation</RootNamespace>
+    <Name>Documentation</Name>
+    <!-- SHFB properties -->
+    <FrameworkVersion>.NET Framework 4.5</FrameworkVersion>
+    <OutputPath>..\apihtml\</OutputPath>
+    <HtmlHelpName>BenchmarkDotNetReferenceManual</HtmlHelpName>
+    <Language>en-US</Language>
+    <HelpFileVersion>1.0.0.0</HelpFileVersion>
+    <MaximumGroupParts>8</MaximumGroupParts>
+    <NamespaceGrouping>True</NamespaceGrouping>
+    <SyntaxFilters>Standard</SyntaxFilters>
+    <SdkLinkTarget>Blank</SdkLinkTarget>
+    <RootNamespaceContainer>True</RootNamespaceContainer>
+    <PresentationStyle>VS2013</PresentationStyle>
+    <Preliminary>False</Preliminary>
+    <NamingMethod>HashedMemberName</NamingMethod>
+    <HelpTitle>BenchmarkDotNet Reference Manual</HelpTitle>
+    <CopyrightText>%28c%29 2013-2016 BenchmarkDotNet</CopyrightText>
+    <CopyrightHref>https://github.com/PerfDotNet/BenchmarkDotNet</CopyrightHref>
+    <ContentPlacement>AboveNamespaces</ContentPlacement>
+    <BuildAssemblerVerbosity>OnlyWarningsAndErrors</BuildAssemblerVerbosity>
+    <HelpFileFormat>Website</HelpFileFormat>
+    <IndentHtml>False</IndentHtml>
+    <KeepLogFile>True</KeepLogFile>
+    <DisableCodeBlockComponent>False</DisableCodeBlockComponent>
+    <CleanIntermediates>True</CleanIntermediates>
+    <WebsiteSdkLinkType>Msdn</WebsiteSdkLinkType>
+    <HtmlSdkLinkType>Msdn</HtmlSdkLinkType>
+    <IncludeFavorites>True</IncludeFavorites>
+    <BinaryTOC>True</BinaryTOC>
+    <TocParentId>-1</TocParentId>
+    <TocParentVersion>100</TocParentVersion>
+    <TopicVersion>100</TopicVersion>
+    <TocOrder>-1</TocOrder>
+    <VendorName>BenchmarkDotNet</VendorName>
+    <MSHelpViewerSdkLinkType>Msdn</MSHelpViewerSdkLinkType>
+    <CatalogVersion>100</CatalogVersion>
+    <CatalogProductId>VS</CatalogProductId>
+    <VisibleItems>Attributes, ExplicitInterfaceImplementations, InheritedMembers, InheritedFrameworkMembers, Protected, SealedProtected, ProtectedInternalAsProtected</VisibleItems>
+    <MissingTags>AutoDocumentCtors, AutoDocumentDispose</MissingTags>
+    <WorkingPath>%TEMP%\SHFB_BDN\</WorkingPath>
+    <ComponentConfigurations>
+      <ComponentConfig id="API Token Resolution" enabled="True" xmlns="">
+        <component id="API Token Resolution">{@TokenFiles}
+<replace elements="/*//token" item="string(.)" /></component>
+      </ComponentConfig>
+<ComponentConfig id="Code Block Component" enabled="True" xmlns=""><component id="Code Block Component">
+  <basePath value="{@HtmlEncProjectFolder}" />
+  <outputPaths>{@HelpFormatOutputPaths}</outputPaths>
+  <allowMissingSource value="false" />
+  <removeRegionMarkers value="false" />
+  <colorizer syntaxFile="{@SHFBFolder}PresentationStyles\Colorizer\highlight.xml" styleFile="{@SHFBFolder}PresentationStyles\Colorizer\highlight.xsl" stylesheet="{@SHFBFolder}PresentationStyles\Colorizer\highlight.css" scriptFile="{@SHFBFolder}PresentationStyles\Colorizer\highlight.js" disabled="{@DisableCodeBlockComponent}" language="cs" tabSize="0" numberLines="false" outlining="false" keepSeeTags="false" defaultTitle="true" />
+</component></ComponentConfig></ComponentConfigurations>
+    <DocumentationSources>
+      <DocumentationSource sourceFile="..\..\src\BenchmarkDotNet\bin\Debug\net45\BenchmarkDotNet.Core.dll" />
+<DocumentationSource sourceFile="..\..\src\BenchmarkDotNet\bin\Debug\net45\BenchmarkDotNet.dll" />
+<DocumentationSource sourceFile="..\..\src\BenchmarkDotNet.Diagnostics.Windows\bin\Debug\net45\BenchmarkDotNet.Diagnostics.Windows.dll" /></DocumentationSources>
+  </PropertyGroup>
+  <!-- There are no properties for these groups.  AnyCPU needs to appear in order for Visual Studio to perform
+			 the build.  The others are optional common platform types that may appear. -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|Win32' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|Win32' ">
+  </PropertyGroup>
+  <!-- Import the SHFB build targets -->
+  <Import Project="$(SHFBROOT)\SandcastleHelpFileBuilder.targets" />
+  <!-- The pre-build and post-build event properties must appear *after* the targets file import in order to be
+			 evaluated correctly. -->
+  <PropertyGroup>
+    <PreBuildEvent>
+    </PreBuildEvent>
+    <PostBuildEvent>
+    </PostBuildEvent>
+    <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
+  </PropertyGroup>
+</Project>

--- a/docs/api/GenerateHtml.cmd
+++ b/docs/api/GenerateHtml.cmd
@@ -1,3 +1,4 @@
 @echo off
-call vsvars32.bat
+REM Uncomment next line if msbuild isn't in the path but vs.net's common7\tools folder is. 
+REM call vsvars32.bat
 msbuild BenchmarkDotNet.shfbproj /v:m 

--- a/docs/api/GenerateHtml.cmd
+++ b/docs/api/GenerateHtml.cmd
@@ -1,0 +1,3 @@
+@echo off
+call vsvars32.bat
+msbuild BenchmarkDotNet.shfbproj /v:m 

--- a/src/BenchmarkDotNet.Core/project.json
+++ b/src/BenchmarkDotNet.Core/project.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "title": "BenchmarkDotNet.Core",
   "version": "0.9.8-develop",
   "authors": [ "Andrey Akinshin", "Jon Skeet", "Matt Warren" ],
@@ -35,7 +35,8 @@
   },
   "buildOptions": {
     "embed": [ "Templates/*" ],
-    "nowarn": [ "1591" ]
+    "nowarn": [ "1591" ],
+    "xmlDoc": true
   },
   "frameworks": {
     "net45": {

--- a/src/BenchmarkDotNet.Diagnostics.Windows/project.json
+++ b/src/BenchmarkDotNet.Diagnostics.Windows/project.json
@@ -41,6 +41,7 @@
     "Microsoft.Diagnostics.Tracing.TraceEvent": "1.0.41.0"
   },
   "buildOptions": {
-    "nowarn": [ "1591" ]
+    "nowarn": [ "1591" ],
+    "xmlDoc": true
   }
 }

--- a/src/BenchmarkDotNet/project.json
+++ b/src/BenchmarkDotNet/project.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "title": "BenchmarkDotNet",
   "version": "0.9.8-develop",
   "authors": [ "Andrey Akinshin", "Jon Skeet", "Matt Warren" ],
@@ -34,7 +34,8 @@
     }
   },
   "buildOptions": {
-    "nowarn": [ "1591" ]
+    "nowarn": [ "1591" ],
+    "xmlDoc": true
   },
   "frameworks": {
     "net45": {


### PR DESCRIPTION
Uses Sandcastle Help File Builder: https://github.com/EWSoftware/SHFB. This has to be installed.
It generates an API reference manual similar to MSDN, including search. This is configurable through the GUI of SHFB, if you want to change anything, or alter the shfbproj file in a text editor. Generation uses msbuild so vsvars32.bat is called to get msbuild into the path. If this isn't needed, remove it from the generatehtml.cmd file It generates output into docs\apihtml which is ignored in the gitignore file.

For #219 