### PR TITLE
Better wording for error message

### DIFF
--- a/src/BenchmarkDotNet.Core/Running/BenchmarkConverter.cs
+++ b/src/BenchmarkDotNet.Core/Running/BenchmarkConverter.cs
@@ -138,7 +138,7 @@ namespace BenchmarkDotNet.Running
             while (declaringType != null)
             {
                 if (!declaringType.GetTypeInfo().IsPublic && !declaringType.GetTypeInfo().IsNestedPublic)
-                    throw new InvalidOperationException($"{methodType} method {methodInfo.Name} defined within type {declaringType.FullName} has incorrect access modifiers.\nDeclaring type must be public.");
+                    throw new InvalidOperationException($"{declaringType.FullName} containing {methodType} method {methodInfo.Name} has incorrect access modifiers.\nDeclaring type must be public.");
 
                 declaringType = declaringType.DeclaringType;
             }


### PR DESCRIPTION
If you have a code like this:
```
class A 
{
    [Benchmark]
    public void Test()
    {
        var b = 42;
    }
}
```
you will get a message
> Benchmark method Test defined within type MyProject.A has incorrect access modifiers.

>Declaring type must be public.
IMO it's confusing as it implies that method, not type has incorrect access modifier.
I think
>MyProject.A containing Benchmark method Test has incorrect access modifiers.
is less confusing.