### PR TITLE
Allow benchmark classes and methods to be executed using TestDriven.Net

### DIFF
--- a/BenchmarkDotNet.sln
+++ b/BenchmarkDotNet.sln
@@ -66,6 +66,10 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "BenchmarkDotNet.Core", "src
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "BenchmarkDotNet.Toolchains.Roslyn", "src\BenchmarkDotNet.Toolchains.Roslyn\BenchmarkDotNet.Toolchains.Roslyn.xproj", "{F5785871-7E2C-4894-85DE-A28EACB1D9B5}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "BenchmarkDotNet.TestDriven", "src\BenchmarkDotNet.TestDriven\BenchmarkDotNet.TestDriven.xproj", "{EA3B1CCF-9146-40F6-84D0-DC98C940F78B}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "BenchmarkDotNet.IntegrationTests.TestDriven", "tests\BenchmarkDotNet.IntegrationTests.TestDriven\BenchmarkDotNet.IntegrationTests.TestDriven.xproj", "{FD33C931-6F5B-4F55-959C-605408BA1C3B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -136,6 +140,14 @@ Global
 		{F5785871-7E2C-4894-85DE-A28EACB1D9B5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F5785871-7E2C-4894-85DE-A28EACB1D9B5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F5785871-7E2C-4894-85DE-A28EACB1D9B5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EA3B1CCF-9146-40F6-84D0-DC98C940F78B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EA3B1CCF-9146-40F6-84D0-DC98C940F78B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EA3B1CCF-9146-40F6-84D0-DC98C940F78B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EA3B1CCF-9146-40F6-84D0-DC98C940F78B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FD33C931-6F5B-4F55-959C-605408BA1C3B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FD33C931-6F5B-4F55-959C-605408BA1C3B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FD33C931-6F5B-4F55-959C-605408BA1C3B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FD33C931-6F5B-4F55-959C-605408BA1C3B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -157,5 +169,7 @@ Global
 		{24D62335-B878-4F00-8555-C6DC3E40FA70} = {602236FF-A83D-43BA-9EE7-A4B0BE2CA4B3}
 		{95F5D645-19E3-432F-95D4-C5EA374DD15B} = {D6597E3A-6892-4A68-8E14-042FC941FDA2}
 		{F5785871-7E2C-4894-85DE-A28EACB1D9B5} = {D6597E3A-6892-4A68-8E14-042FC941FDA2}
+		{EA3B1CCF-9146-40F6-84D0-DC98C940F78B} = {D6597E3A-6892-4A68-8E14-042FC941FDA2}
+		{FD33C931-6F5B-4F55-959C-605408BA1C3B} = {14195214-591A-45B7-851A-19D3BA2413F9}
 	EndGlobalSection
 EndGlobal

--- a/samples/BenchmarkDotNet.Samples/Properties/AssemblyInfo.cs
+++ b/samples/BenchmarkDotNet.Samples/Properties/AssemblyInfo.cs
@@ -2,7 +2,6 @@
 using System.Runtime.InteropServices;
 using BenchmarkDotNet.Properties;
 using BenchmarkDotNet.TestDriven;
-using TestDriven.Framework;
 
 [assembly: AssemblyTitle(BenchmarkDotNetInfo.Title + ".Samples")]
 [assembly: AssemblyProduct(BenchmarkDotNetInfo.Title + ".Samples")]
@@ -19,4 +18,5 @@ using TestDriven.Framework;
 [assembly: ComVisible(false)]
 [assembly: Guid("6f2232a9-0d0c-46cf-b08c-f6e28ab612e3")]
 
-[assembly: CustomTestRunner(typeof(FastAndDirtyBenchmarkTestRunner))]
+[assembly: BenchmarkTestRunner(typeof(FastAndDirtyConfig))]
+//[assembly: BenchmarkTestRunner(typeof(FastAndDirtyClrAndCoreConfig))]

--- a/samples/BenchmarkDotNet.Samples/Properties/AssemblyInfo.cs
+++ b/samples/BenchmarkDotNet.Samples/Properties/AssemblyInfo.cs
@@ -1,6 +1,8 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 using BenchmarkDotNet.Properties;
+using BenchmarkDotNet.TestDriven;
+using TestDriven.Framework;
 
 [assembly: AssemblyTitle(BenchmarkDotNetInfo.Title + ".Samples")]
 [assembly: AssemblyProduct(BenchmarkDotNetInfo.Title + ".Samples")]
@@ -16,3 +18,5 @@ using BenchmarkDotNet.Properties;
 
 [assembly: ComVisible(false)]
 [assembly: Guid("6f2232a9-0d0c-46cf-b08c-f6e28ab612e3")]
+
+[assembly: CustomTestRunner(typeof(FastAndDirtyBenchmarkTestRunner))]

--- a/samples/BenchmarkDotNet.Samples/project.json
+++ b/samples/BenchmarkDotNet.Samples/project.json
@@ -49,6 +49,9 @@
   "dependencies": {
     "BenchmarkDotNet": {
       "target": "project"
+    },
+    "BenchmarkDotNet.TestDriven": {
+      "target": "project"
     }
   }
 }

--- a/src/BenchmarkDotNet.TestDriven/BenchmarkDotNet.TestDriven.xproj
+++ b/src/BenchmarkDotNet.TestDriven/BenchmarkDotNet.TestDriven.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>ea3b1ccf-9146-40f6-84d0-dc98c940f78b</ProjectGuid>
+    <RootNamespace>BenchmarkDotNet.TestDriven</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/BenchmarkDotNet.TestDriven/BenchmarkTestRunner.cs
+++ b/src/BenchmarkDotNet.TestDriven/BenchmarkTestRunner.cs
@@ -1,0 +1,105 @@
+﻿using System.Reflection;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Reports;
+using BenchmarkDotNet.Attributes;
+using TestDriven.Framework;
+
+namespace BenchmarkDotNet.TestDriven
+{
+    public abstract class BenchmarkTestRunner : ITestRunner
+    {
+        public abstract IConfig GetConfig();
+
+        public TestRunState RunMember(ITestListener testListener, Assembly assembly, MemberInfo member)
+        {
+            var summary = run(member);
+            if (summary == null)
+            {
+                return TestRunState.NoTests;
+            }
+
+            foreach (var benchmark in summary.Benchmarks)
+            {
+                var testResult = getTestResult(benchmark);
+                testListener.TestFinished(testResult);
+            }
+
+            testListener.TestResultsUrl(summary.ResultsDirectoryPath);
+
+            return TestRunState.Success;
+        }
+
+
+        static TestResult getTestResult(Benchmark benchmark)
+        {
+            var testResult = new TestResult();
+            testResult.TestRunnerName = getTestRunnerName();
+            testResult.Name = getTestName(benchmark.Target.Method);
+            testResult.Method = benchmark.Target.Method;
+            return testResult;
+        }
+
+        static string getTestName(MethodInfo method)
+        {
+            return method.DeclaringType.FullName + "." + method.Name;
+        }
+
+        static string getTestRunnerName()
+        {
+            var version = typeof(BenchmarkAttribute).GetTypeInfo().Assembly.GetName().Version;
+            return string.Format("BenchmarkDotNet {0}.{1}.{2}", version.Major, version.Minor, version.Build);
+        }
+
+        Summary run(MemberInfo member)
+        {
+            if (member is TypeInfo)
+            {
+                var type = (TypeInfo)member;
+                if (isBenchmarkType(type))
+                {
+                    return BenchmarkRunner.Run(type.AsType(), GetConfig());
+                }
+            }
+            else if (member is MethodInfo)
+            {
+                var method = (MethodInfo)member;
+                if (isBenchmarkMethod(method))
+                {
+                    var type = method.DeclaringType;
+                    return BenchmarkRunner.Run(type, new[] { method }, GetConfig());
+                }
+            }
+
+            return null;
+        }
+
+        static bool isBenchmarkType(TypeInfo type)
+        {
+            foreach (var method in type.GetMethods())
+            {
+                if (isBenchmarkMethod(method))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        static bool isBenchmarkMethod(MethodInfo method)
+        {
+            return method.GetCustomAttribute<BenchmarkAttribute>() != null;
+        }
+
+        public TestRunState RunNamespace(ITestListener testListener, Assembly assembly, string ns)
+        {
+            return TestRunState.NoTests;
+        }
+
+        public TestRunState RunAssembly(ITestListener testListener, Assembly assembly)
+        {
+            return TestRunState.NoTests;
+        }
+    }
+}

--- a/src/BenchmarkDotNet.TestDriven/BenchmarkTestRunnerAttribute.cs
+++ b/src/BenchmarkDotNet.TestDriven/BenchmarkTestRunnerAttribute.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using TestDriven.Framework;
+
+namespace BenchmarkDotNet.TestDriven
+{
+    public class BenchmarkTestRunnerAttribute : CustomTestRunnerAttribute
+    {
+        public BenchmarkTestRunnerAttribute(Type configType) : base(typeof(BenchmarkTestRunner))
+        {
+            ConfigType = configType;
+        }
+
+        public Type ConfigType
+        {
+            get;
+        }
+    }
+}

--- a/src/BenchmarkDotNet.TestDriven/FastAndDirtyBenchmarkTestRunner.cs
+++ b/src/BenchmarkDotNet.TestDriven/FastAndDirtyBenchmarkTestRunner.cs
@@ -1,0 +1,22 @@
+﻿using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Configs;
+
+namespace BenchmarkDotNet.TestDriven
+{
+    public class FastAndDirtyBenchmarkTestRunner : BenchmarkTestRunner
+    {
+        // See https://perfdotnet.github.io/BenchmarkDotNet/faq.htm
+        public override IConfig GetConfig()
+        {
+            var config = new ManualConfig();
+            config.Add(DefaultConfig.Instance);
+            config.Add(Job.Default
+                .WithLaunchCount(1)     // benchmark process will be launched only once
+                .WithIterationTime(100) // 100ms per iteration
+                .WithWarmupCount(3)     // 3 warmup iteration
+                .WithTargetCount(3)     // 3 target iteration
+            );
+            return config;
+        }
+    }
+}

--- a/src/BenchmarkDotNet.TestDriven/FastAndDirtyClrAndCoreConfig.cs
+++ b/src/BenchmarkDotNet.TestDriven/FastAndDirtyClrAndCoreConfig.cs
@@ -1,0 +1,28 @@
+﻿using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Configs;
+
+namespace BenchmarkDotNet.TestDriven
+{
+    // See https://perfdotnet.github.io/BenchmarkDotNet/faq.htm
+    public class FastAndDirtyClrAndCoreConfig : ManualConfig
+    {
+        public FastAndDirtyClrAndCoreConfig()
+        {
+            Add(DefaultConfig.Instance);
+
+            Add(Job.Clr
+                .WithLaunchCount(1)     // benchmark process will be launched only once
+                .WithIterationTime(100) // 100ms per iteration
+                .WithWarmupCount(3)     // 3 warmup iteration
+                .WithTargetCount(3)     // 3 target iteration
+            );
+
+            Add(Job.Core
+                .WithLaunchCount(1)     // benchmark process will be launched only once
+                .WithIterationTime(100) // 100ms per iteration
+                .WithWarmupCount(3)     // 3 warmup iteration
+                .WithTargetCount(3)     // 3 target iteration
+            );
+        }
+    }
+}

--- a/src/BenchmarkDotNet.TestDriven/FastAndDirtyConfig.cs
+++ b/src/BenchmarkDotNet.TestDriven/FastAndDirtyConfig.cs
@@ -3,20 +3,19 @@ using BenchmarkDotNet.Configs;
 
 namespace BenchmarkDotNet.TestDriven
 {
-    public class FastAndDirtyBenchmarkTestRunner : BenchmarkTestRunner
+    // See https://perfdotnet.github.io/BenchmarkDotNet/faq.htm
+    public class FastAndDirtyConfig : ManualConfig
     {
-        // See https://perfdotnet.github.io/BenchmarkDotNet/faq.htm
-        public override IConfig GetConfig()
+        public FastAndDirtyConfig()
         {
-            var config = new ManualConfig();
-            config.Add(DefaultConfig.Instance);
-            config.Add(Job.Default
+            Add(DefaultConfig.Instance);
+
+            Add(Job.Default
                 .WithLaunchCount(1)     // benchmark process will be launched only once
                 .WithIterationTime(100) // 100ms per iteration
                 .WithWarmupCount(3)     // 3 warmup iteration
                 .WithTargetCount(3)     // 3 target iteration
             );
-            return config;
         }
     }
 }

--- a/src/BenchmarkDotNet.TestDriven/Properties/AssemblyInfo.cs
+++ b/src/BenchmarkDotNet.TestDriven/Properties/AssemblyInfo.cs
@@ -1,0 +1,22 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+using TestDriven.Framework;
+using BenchmarkDotNet.TestDriven;
+
+[assembly: CustomTestRunner(typeof(FastAndDirtyBenchmarkTestRunner))]
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("BenchmarkDotNet.TestDriven")]
+[assembly: AssemblyTrademark("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("ea3b1ccf-9146-40f6-84d0-dc98c940f78b")]

--- a/src/BenchmarkDotNet.TestDriven/Properties/AssemblyInfo.cs
+++ b/src/BenchmarkDotNet.TestDriven/Properties/AssemblyInfo.cs
@@ -1,9 +1,5 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
-using TestDriven.Framework;
-using BenchmarkDotNet.TestDriven;
-
-[assembly: CustomTestRunner(typeof(FastAndDirtyBenchmarkTestRunner))]
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information

--- a/src/BenchmarkDotNet.TestDriven/project.json
+++ b/src/BenchmarkDotNet.TestDriven/project.json
@@ -1,18 +1,89 @@
 ﻿{
-  "version": "1.0.0-*",
-
+  "title": "BenchmarkDotNet.TestDriven",
+  "version": "0.9.9-develop",
+  "authors": [ "Jamie Cansdale", "Andrey Akinshin", "Jon Skeet", "Matt Warren" ],
+  "description": "Adapter to allow BenchmarkDotNet benchmarks to be run using TestDriven.Net",
+  "copyright": "Jamie Cansdale, Andrey Akinshin, Jon Skeet, Matt Warren",
+  "packOptions": {
+    "owners": [ "Jamie Cansdale", "Andrey Akinshin", "Jon Skeet", "Matt Warren" ],
+    "licenseUrl": "https://github.com/PerfDotNet/BenchmarkDotNet/blob/master/LICENSE.md",
+    "projectUrl": "https://github.com/PerfDotNet/BenchmarkDotNet",
+    "iconUrl": "https://raw.githubusercontent.com/PerfDotNet/BenchmarkDotNet/master/BenchmarkDotNet/BenchmarkDotNet.png",
+    "requireLicenseAcceptance": false,
+    "repository": {
+      "type": "git",
+      "url": "https://github.com/PerfDotNet/BenchmarkDotNet"
+    },
+    "tags": [ "benchmark benchmarking performance testdriven tdnet" ]
+  },
+  "language": "en-US",
+  "configurations": {
+    "Debug": {
+      "buildOptions": {
+        "define": [ "DEBUG", "TRACE" ]
+      }
+    },
+    "Release": {
+      "buildOptions": {
+        "define": [ "RELEASE", "TRACE" ],
+        "optimize": true,
+        "xmlDoc": true,
+        "keyFile": "../../strongNameKey.snk",
+        "strongName": true
+      }
+    }
+  },
+  "buildOptions": {
+    "embed": [ "Templates/*" ],
+    "nowarn": [ "1591" ],
+    "xmlDoc": true
+  },
   "dependencies": {
     "BenchmarkDotNet": {
       "target": "project"
     },
     "TestDriven.Framework": "2.0.0-alpha2"
   },
-
   "frameworks": {
-    "net45": { },
-    "netstandard1.6": {
+    "net45": {
+      "buildOptions": {
+        "define": [ "CLASSIC" ]
+      },
+      "frameworkAssemblies": {
+        "System.Management": "4.0.0.0",
+        "System.Xml": "4.0.0.0"
+      },
       "dependencies": {
-        "NETStandard.Library": "1.6.0"
+        "System.Threading.Tasks.Extensions": "4.0.0"
+      }
+    },
+    "netstandard1.6": {
+      "buildOptions": {
+        "define": [ "CORE" ]
+      },
+      "dependencies": {
+        "System.Linq": "4.1.0",
+        "System.Resources.ResourceManager": "4.0.1",
+        "Microsoft.CSharp": "4.0.1",
+        "Microsoft.Win32.Primitives": "4.0.1",
+        "System.Console": "4.0.0",
+        "System.Text.RegularExpressions": "4.1.0",
+        "System.Threading": "4.0.11",
+        "System.Reflection": "4.1.0",
+        "System.Reflection.Primitives": "4.0.1",
+        "System.Reflection.TypeExtensions": "4.1.0",
+        "System.Threading.Tasks.Extensions": "4.0.0",
+        "System.Threading.Thread": "4.0.0",
+        "System.Diagnostics.Process": "4.1.0",
+        "System.IO.FileSystem": "4.0.1",
+        "System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
+        "System.Runtime.Serialization.Primitives": "4.1.1",
+        "System.Diagnostics.Tools": "4.0.1",
+        "System.Runtime.InteropServices": "4.1.0",
+        "Microsoft.DotNet.InternalAbstractions": "1.0.0",
+        "System.Reflection.Extensions": "4.0.1",
+        "System.Diagnostics.Debug": "4.0.11",
+        "System.Xml.XPath.XmlDocument": "4.0.1"
       }
     }
   }

--- a/src/BenchmarkDotNet.TestDriven/project.json
+++ b/src/BenchmarkDotNet.TestDriven/project.json
@@ -1,0 +1,19 @@
+﻿{
+  "version": "1.0.0-*",
+
+  "dependencies": {
+    "BenchmarkDotNet": {
+      "target": "project"
+    },
+    "TestDriven.Framework": "2.0.0-alpha2"
+  },
+
+  "frameworks": {
+    "net45": { },
+    "netstandard1.6": {
+      "dependencies": {
+        "NETStandard.Library": "1.6.0"
+      }
+    }
+  }
+}

--- a/tests/BenchmarkDotNet.IntegrationTests.TestDriven/BenchmarkDotNet.IntegrationTests.TestDriven.xproj
+++ b/tests/BenchmarkDotNet.IntegrationTests.TestDriven/BenchmarkDotNet.IntegrationTests.TestDriven.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>fd33c931-6f5b-4f55-959c-605408ba1c3b</ProjectGuid>
+    <RootNamespace>BenchmarkDotNet.TestDriven.Tests</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/tests/BenchmarkDotNet.IntegrationTests.TestDriven/BenchmarkTestRunnerTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests.TestDriven/BenchmarkTestRunnerTests.cs
@@ -16,8 +16,7 @@
         [Test]
         public void RunMember_NoBenchmarks_NoTests()
         {
-            var benchmarkTestRunner = Substitute.For<BenchmarkTestRunner>();
-            benchmarkTestRunner.GetConfig().Returns(new SuperQuickConfig());
+            var benchmarkTestRunner = new BenchmarkTestRunner(typeof(QuickConfig));
             var testListener = Substitute.For<ITestListener>();
             var targetType = typeof(NoBenchmarks).GetTypeInfo();
 
@@ -29,8 +28,7 @@
         [Test]
         public void RunMember_SomeBenchmarks_Success2Tests()
         {
-            var benchmarkTestRunner = Substitute.For<BenchmarkTestRunner>();
-            benchmarkTestRunner.GetConfig().Returns(new SuperQuickConfig());
+            var benchmarkTestRunner = new BenchmarkTestRunner(typeof(QuickConfig));
             var testListener = Substitute.For<ITestListener>();
             var targetType = typeof(SomeBenchmarks).GetTypeInfo();
 
@@ -43,8 +41,7 @@
         [Test]
         public void RunMember_SomeBenchmarks_TestRunnerName()
         {
-            var benchmarkTestRunner = Substitute.For<BenchmarkTestRunner>();
-            benchmarkTestRunner.GetConfig().Returns(new SuperQuickConfig());
+            var benchmarkTestRunner = new BenchmarkTestRunner(typeof(QuickConfig));
             var testListener = Substitute.For<ITestListener>();
             var targetType = typeof(SomeBenchmarks).GetTypeInfo();
             var version = typeof(BenchmarkAttribute).GetTypeInfo().Assembly.GetName().Version;
@@ -58,8 +55,7 @@
         [Test]
         public void RunMember_SomeBenchmarks_TestResultName()
         {
-            var benchmarkTestRunner = Substitute.For<BenchmarkTestRunner>();
-            benchmarkTestRunner.GetConfig().Returns(new SuperQuickConfig());
+            var benchmarkTestRunner = new BenchmarkTestRunner(typeof(QuickConfig));
             var testListener = Substitute.For<ITestListener>();
             var targetType = typeof(SomeBenchmarks).GetTypeInfo();
             var method = new Action(new SomeBenchmarks().Benchmark1).GetMethodInfo();
@@ -73,8 +69,7 @@
         [Test]
         public void RunMember_SomeBenchmarksBenchmark1_TestResultName()
         {
-            var benchmarkTestRunner = Substitute.For<BenchmarkTestRunner>();
-            benchmarkTestRunner.GetConfig().Returns(new SuperQuickConfig());
+            var benchmarkTestRunner = new BenchmarkTestRunner(typeof(QuickConfig));
             var testListener = Substitute.For<ITestListener>();
             var targetType = typeof(SomeBenchmarks).GetTypeInfo();
             var method = new Action(new SomeBenchmarks().Benchmark1).GetMethodInfo();
@@ -85,11 +80,24 @@
             testListener.Received(1).TestFinished(Arg.Any<TestResult>());
             testListener.Received().TestFinished(Arg.Is<TestResult>(r => r.Name == testName));
         }
+
+        [Test]
+        public void RunMember_ConfigTypeNotIConfig_ErrorWithWarning()
+        {
+            var benchmarkTestRunner = new BenchmarkTestRunner(typeof(object));
+            var testListener = Substitute.For<ITestListener>();
+            var targetType = typeof(SomeBenchmarks).GetTypeInfo();
+
+            var testRunState = benchmarkTestRunner.RunMember(testListener, targetType.Assembly, targetType);
+
+            Assert.That(testRunState, Is.EqualTo(TestRunState.Error));
+            testListener.Received(1).WriteLine(Arg.Any<string>(), Category.Warning);
+        }
     }
 
-    class SuperQuickConfig : ManualConfig
+    class QuickConfig : ManualConfig
     {
-        internal SuperQuickConfig()
+        public QuickConfig()
         {
             Add(Job.Default
                 .WithLaunchCount(1)     // benchmark process will be launched only once

--- a/tests/BenchmarkDotNet.IntegrationTests.TestDriven/BenchmarkTestRunnerTests.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests.TestDriven/BenchmarkTestRunnerTests.cs
@@ -1,0 +1,119 @@
+﻿namespace TestDriven.Benchmark.Tests
+{
+    using System;
+    using System.Reflection;
+    using BenchmarkDotNet.Running;
+    using BenchmarkDotNet.Attributes;
+    using BenchmarkDotNet.Configs;
+    using BenchmarkDotNet.TestDriven;
+    using BenchmarkDotNet.Jobs;
+    using NSubstitute;
+    using Framework;
+    using NUnit.Framework;
+
+    public class BenckmarkTestRunnerTests
+    {
+        [Test]
+        public void RunMember_NoBenchmarks_NoTests()
+        {
+            var benchmarkTestRunner = Substitute.For<BenchmarkTestRunner>();
+            benchmarkTestRunner.GetConfig().Returns(new SuperQuickConfig());
+            var testListener = Substitute.For<ITestListener>();
+            var targetType = typeof(NoBenchmarks).GetTypeInfo();
+
+            var testRunState = benchmarkTestRunner.RunMember(testListener, targetType.Assembly, targetType);
+
+            Assert.That(testRunState, Is.EqualTo(TestRunState.NoTests));
+        }
+
+        [Test]
+        public void RunMember_SomeBenchmarks_Success2Tests()
+        {
+            var benchmarkTestRunner = Substitute.For<BenchmarkTestRunner>();
+            benchmarkTestRunner.GetConfig().Returns(new SuperQuickConfig());
+            var testListener = Substitute.For<ITestListener>();
+            var targetType = typeof(SomeBenchmarks).GetTypeInfo();
+
+            var testRunState = benchmarkTestRunner.RunMember(testListener, targetType.Assembly, targetType);
+
+            Assert.That(testRunState, Is.EqualTo(TestRunState.Success));
+            testListener.Received(2).TestFinished(Arg.Any<TestResult>());
+        }
+
+        [Test]
+        public void RunMember_SomeBenchmarks_TestRunnerName()
+        {
+            var benchmarkTestRunner = Substitute.For<BenchmarkTestRunner>();
+            benchmarkTestRunner.GetConfig().Returns(new SuperQuickConfig());
+            var testListener = Substitute.For<ITestListener>();
+            var targetType = typeof(SomeBenchmarks).GetTypeInfo();
+            var version = typeof(BenchmarkAttribute).GetTypeInfo().Assembly.GetName().Version;
+            var expectedTestRunnerName = string.Format("BenchmarkDotNet {0}.{1}.{2}", version.Major, version.Minor, version.Build);
+
+            var testRunState = benchmarkTestRunner.RunMember(testListener, targetType.Assembly, targetType);
+
+            testListener.Received().TestFinished(Arg.Is<TestResult>(r => r.TestRunnerName == expectedTestRunnerName));
+        }
+
+        [Test]
+        public void RunMember_SomeBenchmarks_TestResultName()
+        {
+            var benchmarkTestRunner = Substitute.For<BenchmarkTestRunner>();
+            benchmarkTestRunner.GetConfig().Returns(new SuperQuickConfig());
+            var testListener = Substitute.For<ITestListener>();
+            var targetType = typeof(SomeBenchmarks).GetTypeInfo();
+            var method = new Action(new SomeBenchmarks().Benchmark1).GetMethodInfo();
+            var testName = method.DeclaringType.FullName + "." + method.Name;
+
+            var testRunState = benchmarkTestRunner.RunMember(testListener, targetType.Assembly, targetType);
+
+            testListener.Received().TestFinished(Arg.Is<TestResult>(r => r.Name == testName));
+        }
+
+        [Test]
+        public void RunMember_SomeBenchmarksBenchmark1_TestResultName()
+        {
+            var benchmarkTestRunner = Substitute.For<BenchmarkTestRunner>();
+            benchmarkTestRunner.GetConfig().Returns(new SuperQuickConfig());
+            var testListener = Substitute.For<ITestListener>();
+            var targetType = typeof(SomeBenchmarks).GetTypeInfo();
+            var method = new Action(new SomeBenchmarks().Benchmark1).GetMethodInfo();
+            var testName = method.DeclaringType.FullName + "." + method.Name;
+
+            var testRunState = benchmarkTestRunner.RunMember(testListener, targetType.Assembly, method);
+
+            testListener.Received(1).TestFinished(Arg.Any<TestResult>());
+            testListener.Received().TestFinished(Arg.Is<TestResult>(r => r.Name == testName));
+        }
+    }
+
+    class SuperQuickConfig : ManualConfig
+    {
+        internal SuperQuickConfig()
+        {
+            Add(Job.Default
+                .WithLaunchCount(1)     // benchmark process will be launched only once
+                .WithIterationTime(1)   // 1ms per iteration
+                .WithWarmupCount(1)     // 1 warmup iteration
+                .WithTargetCount(1)     // 1 target iteration
+            );
+        }
+    }
+
+    public class NoBenchmarks
+    {
+    }
+
+    public class SomeBenchmarks
+    {
+        [Benchmark]
+        public void Benchmark1()
+        {
+        }
+
+        [Benchmark]
+        public void Benchmark2()
+        {
+        }
+    }
+}

--- a/tests/BenchmarkDotNet.IntegrationTests.TestDriven/Properties/AssemblyInfo.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests.TestDriven/Properties/AssemblyInfo.cs
@@ -1,0 +1,19 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("BenchmarkDotNet.TestDriven.Tests")]
+[assembly: AssemblyTrademark("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("fd33c931-6f5b-4f55-959c-605408ba1c3b")]

--- a/tests/BenchmarkDotNet.IntegrationTests.TestDriven/project.json
+++ b/tests/BenchmarkDotNet.IntegrationTests.TestDriven/project.json
@@ -1,0 +1,27 @@
+﻿{
+  "version": "1.0.0-*",
+  "buildOptions": {
+  },
+
+  "dependencies": {
+    "NUnit": "3.4.1",
+    "dotnet-test-nunit": "3.4.0-*",
+    "BenchmarkDotNet.TestDriven": "1.0.0-*",
+    "NSubstitute": "2.0.0-*"
+  },
+
+  "testRunner": "nunit",
+
+  "frameworks": {
+    "net451": { },
+    "netcoreapp1.0": {
+      "imports": "dnxcore50",
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This branch adds support for executing benchmarks using TestDriven.Net. To try it, simply reference the `BenchmarkDotNet.TestDriven` package and add an attribute like this:

```
[assembly: BenchmarkTestRunner(typeof(FastAndDirtyConfig))]
```

If you have [TestDriven.Net](http://testdriven.net) installed, you can then right-click `Run Test(s)` inside any class or method that contains a `[Benchmark]` attribute.

I've added one of these attributes to the `BenchmarkDotNet.Samples` project so you can try it there:
https://github.com/jcansdale/BenchmarkDotNet/blob/master/samples/BenchmarkDotNet.Samples/Properties/AssemblyInfo.cs

Thanks for a great tool and let me know if you have any questions. :smile: 