### PR TITLE
Make shipped assemblies have CLSCompliant(true) applied

### DIFF
--- a/src/BenchmarkDotNet.Core/Properties/AssemblyInfo.cs
+++ b/src/BenchmarkDotNet.Core/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using BenchmarkDotNet.Properties;
@@ -17,6 +18,8 @@ using BenchmarkDotNet.Properties;
 
 [assembly: ComVisible(false)]
 [assembly: Guid("95f5d645-19e3-432f-95d4-c5ea374dd15b")]
+
+[assembly: CLSCompliant(true)]
 
 #if RELEASE
 [assembly: InternalsVisibleTo("BenchmarkDotNet.Toolchains.Roslyn,PublicKey=" + BenchmarkDotNetInfo.PublicKey)]

--- a/src/BenchmarkDotNet.Diagnostics.Windows/Properties/AssemblyInfo.cs
+++ b/src/BenchmarkDotNet.Diagnostics.Windows/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using BenchmarkDotNet.Properties;
 
@@ -16,3 +17,5 @@ using BenchmarkDotNet.Properties;
 
 [assembly: ComVisible(false)]
 [assembly: Guid("7bbae514-895c-4ca5-95ba-b2a1a0c2e0af")]
+
+[assembly: CLSCompliant(true)]

--- a/src/BenchmarkDotNet.Toolchains.Roslyn/Properties/AssemblyInfo.cs
+++ b/src/BenchmarkDotNet.Toolchains.Roslyn/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using BenchmarkDotNet.Properties;
@@ -17,6 +18,8 @@ using BenchmarkDotNet.Properties;
 
 [assembly: ComVisible(false)]
 [assembly: Guid("f5785871-7e2c-4894-85de-a28eacb1d9b5")]
+
+[assembly: CLSCompliant(true)]
 
 #if RELEASE
 [assembly: InternalsVisibleTo("BenchmarkDotNet,PublicKey=" + BenchmarkDotNetInfo.PublicKey)]

--- a/src/BenchmarkDotNet/Properties/AssemblyInfo.cs
+++ b/src/BenchmarkDotNet/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using BenchmarkDotNet.Properties;
@@ -17,6 +18,8 @@ using BenchmarkDotNet.Properties;
 
 [assembly: ComVisible(false)]
 [assembly: Guid("cbba82d3-e650-407f-a0f0-767891d4f04c")]
+
+[assembly: CLSCompliant(true)]
 
 #if RELEASE
 [assembly: InternalsVisibleTo("BenchmarkDotNet.Tests,PublicKey=" + BenchmarkDotNetInfo.PublicKey)]


### PR DESCRIPTION
By applying CLSCompliant(true) attribute to assemblies library consumers no longer need to mark their public code (methods, constructors) referencing BenchmarkDotNet assets as CLSCompliant(false). 