### PR TITLE
Make exported HTML valid, add alternating color to table

### DIFF
--- a/src/BenchmarkDotNet.Core/Exporters/HtmlExporter.cs
+++ b/src/BenchmarkDotNet.Core/Exporters/HtmlExporter.cs
@@ -6,12 +6,29 @@ namespace BenchmarkDotNet.Exporters
 {
     public class HtmlExporter : ExporterBase
     {
+        private const string CssDefinition = @"
+<style type=""text/css"">
+	table { border-collapse: collapse; display: block; width: 100%; overflow: auto; }
+	td, th { padding: 6px 13px; border: 1px solid #ddd; }
+	tr { background-color: #fff; border-top: 1px solid #ccc; }
+	tr:nth-child(even) { background: #f8f8f8; }
+</style>";
+
         protected override string FileExtension => "html";
 
         public static readonly IExporter Default = new HtmlExporter();
 
         public override void ExportToLog(Summary summary, ILogger logger)
         {
+            logger.WriteLine("<!DOCTYPE html>");
+            logger.WriteLine("<html lang='en'>");
+            logger.WriteLine("<head>");
+            logger.WriteLine("<meta charset='utf-8' />");
+            logger.WriteLine("<title>" + summary.Title + "</title>");
+            logger.WriteLine(CssDefinition);
+            logger.WriteLine("</head>");
+
+            logger.WriteLine("<body>");
             logger.Write("<pre><code>");
             logger.WriteLine();
             foreach (var infoLine in HostEnvironmentInfo.GetCurrent().ToFormattedString())
@@ -22,6 +39,9 @@ namespace BenchmarkDotNet.Exporters
             logger.WriteLine();
 
             PrintTable(summary.Table, logger);
+
+            logger.WriteLine("</body>");
+            logger.WriteLine("</html>");
         }
 
         private void PrintTable(SummaryTable table, ILogger logger)
@@ -39,16 +59,20 @@ namespace BenchmarkDotNet.Exporters
 
             logger.WriteLine("<table>");
 
+            logger.Write("<thead>");
             logger.Write("<tr>");
             table.PrintLine(table.FullHeader, logger, "<th>", "</th>");
-            logger.Write("</tr>");
+            logger.WriteLine("</tr>");
+            logger.Write("</thead>");
 
+            logger.Write("<tbody>");
             foreach (var line in table.FullContent)
             {
                 logger.Write("<tr>");
                 table.PrintLine(line, logger, "<td>", "</td>");
                 logger.Write("</tr>");
             }
+            logger.Write("</tbody>");
 
             logger.WriteLine("</table>");
         }


### PR DESCRIPTION
* I made the exported HTML valid, it was missing required container elements.
* Added encoding information
* Added same kind of table styling that GitHub uses, now reading results is easier with alternating row background colors