### PR TITLE
Support Atlassian flavored wiki markup

### DIFF
--- a/src/BenchmarkDotNet.Core/Configs/ConfigParser.cs
+++ b/src/BenchmarkDotNet.Core/Configs/ConfigParser.cs
@@ -98,6 +98,7 @@ namespace BenchmarkDotNet.Configs
                 { "csvmeasurements", new[] { CsvMeasurementsExporter.Default } },
                 { "html", new[] { HtmlExporter.Default } },
                 { "markdown", new [] { MarkdownExporter.Default } },
+                { "atlassian", new[] { MarkdownExporter.Atlassian } },
                 { "stackoverflow", new[] { MarkdownExporter.StackOverflow } },
                 { "github", new[] { MarkdownExporter.GitHub } },
                 { "plain", new[] { PlainExporter.Default } },

--- a/tests/BenchmarkDotNet.IntegrationTests/ValidatorsTest.cs
+++ b/tests/BenchmarkDotNet.IntegrationTests/ValidatorsTest.cs
@@ -17,6 +17,7 @@ namespace BenchmarkDotNet.IntegrationTests
 
         private readonly IExporter[] AllKnownExportersThatSupportExportToLog =
             {
+                MarkdownExporter.Atlassian,
                 MarkdownExporter.Console,
                 MarkdownExporter.Default,
                 MarkdownExporter.GitHub,


### PR DESCRIPTION
I made needed tweaks to MarkdownExporter so that it supports a little bit more customization. 
- Supports syntax that is used by JIRA (issue tracker) and Confluence (wiki)
- MarkdownExporter.Atlassian introduced
- Support separate markup for start and end of code blocks
- No table header and content separator can be optional

So Atlassian's format is:

{noformat}
anything
{noformat}

|| header 1 || header 2||
|  value 1 | value 2 |

If this is too vendor specific I'm fine with creating my own exporter too, would be just a copy paste of MarkdownExporter though.
